### PR TITLE
Remove classification, keep regression-only with full doc update

### DIFF
--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -21,10 +21,7 @@
 5. [性能评估](#性能评估)
    - [测试已训练模型](#测试已训练模型)
    - [测试不同检查点的模型](#测试不同检查点的模型)
-   - [深入分析分类性能](#深入分析分类性能)
-   - [分析空间混淆关系](#分析空间混淆关系)
 6. [可视化分析](#可视化分析)
-   - [位置类别分布](#位置类别分布)
 7. [常见问题解答](#常见问题解答)
 
 ## 环境配置
@@ -42,7 +39,6 @@ conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch -c nvi
 conda install lightning -c conda-forge
 pip install -U 'tensorboardX' 'tensorboard'
 pip install scikit-learn matplotlib seaborn pandas
-# pip install csikit # 如果需要处理原始 .dat 文件，csikit 似乎是特定工具，请确保其可用性或替换为项目中 data_process.py 的逻辑
 ```
 
 ### 检查CUDA是否可用
@@ -97,51 +93,50 @@ antenna_<天线号>_<x坐标>_<y坐标>.csv
     这有助于识别异常或缺失的数据。
 
 ## 模型概览
-项目提供了三种基于深度学习的室内定位模型，均在 `PyTorch Lightning` 框架下实现。
+项目提供了三种基于深度学习的室内定位回归模型，均在 `PyTorch Lightning` 框架下实现，共同继承 `base_model.py` 中的 `CSIBaseModel` 基类。所有模型直接预测 `(x, y)` 坐标，使用欧氏距离误差（单位：网格单元）衡量性能。
 
 ### CNN_Net
 -   **文件**: `cnn_net_model.py`
 -   **架构**: 纯卷积神经网络。
-    -   包含三层2D卷积层 (`nn.Conv2d`)，用于提取CSI数据的空间特征。
+    -   包含三层2D卷积层 (`nn.Conv2d`, kernel=5, padding=2)，用于提取CSI数据的空间特征。
     -   使用批归一化 (`nn.BatchNorm2d` 和 `nn.BatchNorm1d`) 提高训练稳定性。
-    -   最后通过全连接层 (`nn.Linear`) 进行分类。
+    -   通过全连接层 (FC 1024 → FC 512 → FC 2) 输出 `(x, y)` 坐标。
 -   **特点**: 结构相对简单，训练速度较快，适合作为基线模型。
 
 ### CNN_LSTM_Net
 -   **文件**: `cnn_lstm_net_model.py`
 -   **架构**: 卷积神经网络与长短期记忆网络 (LSTM) 的结合。
-    -   首先通过三层2D卷积层提取空间特征，与 `CNN_Net` 类似。
-    -   卷积层输出的特征图被重塑并输入到LSTM层 (`nn.LSTM`)，用于捕捉CSI数据的时间序列特性。
-    -   LSTM的最后一个时间步的输出用于分类。
--   **特点**: 能够同时学习CSI数据的空间和时间依赖性，通常在高精度定位任务中表现更优。
+    -   首先通过三层2D卷积层提取空间特征。
+    -   卷积层输出的特征图被重塑并输入到LSTM层 (`nn.LSTM`, hidden=100)，用于捕捉CSI数据的时间序列特性。
+    -   取LSTM最后一个时间步的输出，通过 FC(2) 输出 `(x, y)` 坐标。
+-   **特点**: 能够同时学习CSI数据的空间和时间依赖性，通常在高精度定位任务中表现更优，**推荐作为首选模型**。
 
 ### CNN_Transformer_Net
 -   **文件**: `cnn_transformer_model.py`
 -   **架构**: 卷积神经网络与Transformer编码器的结合。
     -   使用两层2D卷积层（包含最大池化 `nn.MaxPool2d`）进行初步特征提取和降维。
-    -   卷积输出被视为一个序列，输入到Transformer编码器层 (`nn.TransformerEncoderLayer`, `nn.TransformerEncoder`)。Transformer利用自注意力机制捕捉序列内各元素间的复杂关系。
-    -   Transformer编码器的输出用于最终分类。
--   **特点**: 强大的序列建模能力，可能在捕捉CSI数据中更长距离或更复杂的依赖关系方面具有优势。需要仔细调整超参数（如 `d_model`, `nhead`）。
-
-所有模型同时支持两种任务模式，通过 `--task` 参数切换：
-- **分类模式** (`--task classification`)：将每个唯一的 `(x,y)` 坐标视为独立类别，使用 CrossEntropyLoss，报告准确率。
-- **回归模式** (`--task regression`)：直接预测 `(x,y)` 坐标，使用 SmoothL1Loss，报告平均欧氏距离误差。
+    -   卷积输出被视为序列，输入到Transformer编码器 (`nn.TransformerEncoder`)，利用自注意力机制捕捉序列内的复杂关系。
+    -   取第一个 token 的输出，通过 FC(2) 输出 `(x, y)` 坐标。
+-   **特点**: 强大的序列建模能力，可能在捕捉CSI数据中更长距离或更复杂的依赖关系方面具有优势。
 
 ## 模型训练
 
 ### 基础训练命令
 
-**分类模式**（将每个位置视为独立类别，报告准确率）：
+训练 CNN_LSTM 模型（推荐，使用默认 Smooth L1 损失）：
 ```powershell
-python main.py --model_type cnn_lstm --data_dir ./dataset --mode train --task classification
+python main.py --model_type cnn_lstm --data_dir ./dataset --mode train
 ```
 
-**回归模式**（直接预测坐标，报告平均距离误差，推荐在分类精度低时使用）：
+训练 CNN 模型：
 ```powershell
-python main.py --model_type cnn_lstm --data_dir ./dataset --mode train --task regression
+python main.py --model_type cnn --data_dir ./dataset --mode train
 ```
 
-将 `--model_type` 替换为 `cnn` 或 `cnn_transformer` 来训练其他模型。
+训练 CNN_Transformer 模型：
+```powershell
+python main.py --model_type cnn_transformer --data_dir ./dataset --mode train
+```
 
 ### 训练与测试模式说明
 系统提供两种运行模式，通过 `--mode` 参数指定：
@@ -157,7 +152,7 @@ python main.py --model_type cnn_lstm --data_dir ./dataset --mode train --task re
 -   `<model_type>` 是您选择的模型 (e.g., `cnn_lstm`)。
 -   `<N>` 是实验的版本号。
 -   `last.ckpt`: 保存最后一个训练周期结束时的模型状态。
--   形如 `<model_type>-best-epoch=XX-val_loss=Y.YYY.ckpt` (或基于 `val_acc`): 保存验证集上性能最佳的模型状态。
+-   形如 `<model_type>-best-epoch=XX-val_dist=Y.YYY.ckpt`: 保存验证集上平均距离误差最小的模型状态。
 
 这些检查点可以通过 `--cpt_path` 参数加载，用于继续训练或进行测试评估。
 
@@ -173,63 +168,65 @@ python main.py --model_type cnn_lstm --data_dir ./dataset --mode train --task re
 -   `--num_workers`: (整数) DataLoader使用的工作进程数。默认为 `8`。
 -   `--fast_dev_run`: (布尔值) 如果为True，则运行一个批次的训练和验证，用于快速调试。默认为 `False`。
 -   `--mode`: (字符串) 运行模式。可选: `'train'`, `'test'`。默认为 `'train'`。
--   `--task`: (字符串) 任务类型。可选: `'classification'`, `'regression'`。默认为 `'classification'`。
-    - `classification`: 将每个 (x,y) 位置视为独立类别，使用交叉熵损失，报告准确率和混淆矩阵。
-    - `regression`: 直接预测 (x,y) 坐标，使用 SmoothL1 损失，报告平均欧氏距离误差（单位：网格单元）、中位误差、误差CDF图。**当分类精度较低时推荐使用。**
+-   `--reg_loss`: (字符串) 回归损失函数。可选: `'smooth_l1'`, `'mse'`, `'mae'`。默认为 `'smooth_l1'`。
+    - `smooth_l1` (Huber Loss): 对离群点鲁棒，兼顾MSE和MAE的优点，**推荐默认选项**。
+    - `mse`: 均方误差，对大误差的惩罚更强，适合希望严格约束大误差的场景。
+    - `mae`: 平均绝对误差，对离群点最鲁棒，适合数据噪声较大的场景。
 -   `--cpt_path`: (字符串) 模型检查点文件的路径。用于从特定检查点继续训练或进行测试。
 
 ### 高级训练选项
-您可以组合使用上述参数进行更细致的训练控制。例如，使用较小的批处理大小和较高的学习率训练 `CNN_Transformer_Net`：
+指定损失函数训练 CNN_LSTM 模型：
 ```powershell
-python main.py --model_type cnn_transformer --data_dir ./dataset --batch_size 64 --lr 0.0005 --max_epochs 200 --time_step 20 --stride 2 --mode train
+# 使用 MAE 损失（对噪声更鲁棒）
+python main.py --model_type cnn_lstm --data_dir ./dataset --mode train --reg_loss mae
+
+# 使用 MSE 损失（对大误差惩罚更强）
+python main.py --model_type cnn_lstm --data_dir ./dataset --mode train --reg_loss mse
 ```
-*注意: `CNN_Transformer_Net` 可能对超参数如 `d_model`, `nhead`, `num_encoder_layers`, `dim_feedforward` 敏感，这些目前在 `cnn_transformer_model.py` 中有默认值，高级用户可以修改模型文件以调整它们。*
+
+训练 CNN_Transformer 模型，指定更多超参数：
+```powershell
+python main.py --model_type cnn_transformer --data_dir ./dataset \
+  --batch_size 64 --lr 0.0005 --max_epochs 200 \
+  --time_step 20 --stride 2 --reg_loss smooth_l1 --mode train
+```
+*注意: `CNN_Transformer_Net` 的 `nhead`, `num_encoder_layers`, `dim_feedforward` 参数目前在 `cnn_transformer_model.py` 中有默认值，高级用户可以修改模型文件进行调整。*
+
+从检查点继续训练：
+```powershell
+python main.py --model_type cnn_lstm --data_dir ./dataset --mode train \
+  --cpt_path ./logs/cnn_lstm/version_0/checkpoints/last.ckpt
+```
 
 ## 性能评估
 
 ### 测试已训练模型
 
-**测试分类模型**（报告准确率和混淆矩阵）：
+测试回归模型，输出平均/中位距离误差、命中率及可视化图表：
 ```powershell
-python main.py --mode test --task classification --model_type cnn_lstm --data_dir ./dataset \
+python main.py --mode test --model_type cnn_lstm --data_dir ./dataset \
   --cpt_path ./logs/cnn_lstm/version_0/checkpoints/last.ckpt
 ```
 
-**测试回归模型**（报告平均距离误差、CDF 图和散点图，保存到 `results/cnn_lstm_results/`）：
-```powershell
-python main.py --mode test --task regression --model_type cnn_lstm --data_dir ./dataset \
-  --cpt_path ./logs/cnn_lstm/version_0/checkpoints/last.ckpt
-```
-
-**注意**: 测试时的 `--task` 参数必须与训练时一致，否则模型结构不匹配。
+测试结果包括：
+- **平均欧氏距离误差** (mean Euclidean distance error，单位：网格单元)
+- **中位欧氏距离误差** (median error)
+- **命中率** (within 1 / 2 / 3 网格单元的样本占比)
+- **误差CDF图**: `{model_name}_regression_cdf.png`（保存到 TensorBoard 日志目录）
+- **预测散点图**: `{model_name}_regression_scatter.png`（真实坐标 vs 预测坐标）
 
 ### 测试不同检查点的模型
 您可以通过更改 `--cpt_path` 参数来测试在不同训练阶段保存的模型，例如测试验证集上表现最佳的模型：
 ```powershell
 # 示例：测试 CNN_LSTM 模型的最佳检查点 (文件名可能因您的训练结果而异)
-python main.py --mode test --model_type cnn_lstm --data_dir ./dataset --cpt_path ./logs/cnn_lstm/version_0/checkpoints/cnn_lstm-best-epoch=XX-val_loss=Y.YYY.ckpt
+python main.py --mode test --model_type cnn_lstm --data_dir ./dataset \
+  --cpt_path ./logs/cnn_lstm/version_0/checkpoints/cnn_lstm-best-epoch=XX-val_dist=Y.YYY.ckpt
 ```
-
-### 深入分析分类性能
-使用 `visualize_classification.py` 脚本来生成混淆矩阵和准确率热图，从而更深入地分析模型的分类性能。
-```powershell
-python visualize_classification.py --model_path ./logs/cnn_lstm/version_0/checkpoints/last.ckpt --model_type cnn_lstm --data_dir ./dataset
-```
--   `--model_path`: 指向要评估的模型检查点文件。
--   `--model_type`: 必须与加载的模型类型一致。
--   `--data_dir`: 数据集目录。
-
-### 分析空间混淆关系
-使用 `analyze_spatial_confusion.py` 脚本来分析模型的预测错误与真实位置和预测位置之间的物理（欧几里得）距离的关系。
-```powershell
-python analyze_spatial_confusion.py --model_path ./logs/cnn_lstm/version_0/checkpoints/last.ckpt --model_type cnn_lstm --data_dir ./dataset
-```
-这有助于理解模型是否倾向于将邻近的位置混淆。
 
 ## 可视化分析
 
-### 位置类别分布
-使用 `visualize_locations.py` 脚本来可视化数据集中定义的位置点的空间分布。
+### 位置分布可视化
+使用 `visualize_locations.py` 脚本来可视化数据集中定义的位置点的空间分布：
 ```powershell
 python visualize_locations.py --data_dir ./dataset
 ```
@@ -240,48 +237,42 @@ python visualize_locations.py --data_dir ./dataset
 ### Q: 如何选择合适的模型?
 A:
 -   **CNN_Net**: 适合作为快速基线或计算资源非常有限的情况。
--   **CNN_LSTM_Net**: 通常在CSI这类具有时空特性的数据上表现良好，推荐作为首选尝试。
+-   **CNN_LSTM_Net**: 通常在CSI这类具有时空特性的数据上表现良好，**推荐作为首选**。
 -   **CNN_Transformer_Net**: 具有强大的建模能力，可能在复杂场景或需要捕捉更长依赖时有优势，但可能需要更多数据和更仔细的调参。
+
+### Q: 如何选择合适的损失函数 (`--reg_loss`)?
+A:
+-   **`smooth_l1`** (默认，推荐): Huber Loss，综合了 MSE 和 MAE 的优点。对小误差采用 L2 惩罚，对大误差（离群点）采用 L1 惩罚，鲁棒性好。
+-   **`mse`**: 均方误差。当您希望模型更严格地约束大误差时选用，但离群点对训练影响较大。
+-   **`mae`**: 平均绝对误差。当数据中存在较多噪声或离群点时选用，收敛速度可能稍慢。
 
 ### Q: 如何处理过拟合问题?
 A:
-1.  **数据增强**: 虽然本项目未直接实现，但可以考虑对CSI信号进行微小的变换。
-2.  **正则化**: 模型中已使用批归一化 (BatchNorm)。可以考虑在全连接层添加 Dropout 或 L2 正则化。
-3.  **早停 (EarlyStopping)**: 已通过 PyTorch Lightning Callbacks 实现，监控 `val_loss`。
+1.  **早停 (EarlyStopping)**: 已通过 PyTorch Lightning Callbacks 实现，监控 `val_dist`（验证集平均距离误差）。
+2.  **学习率调度**: 使用 ReduceLROnPlateau，验证集 `val_dist` 不下降时自动降低学习率。
+3.  **正则化**: 模型中已使用批归一化 (BatchNorm) 和 Dropout。
 4.  **减小模型复杂度**: 尝试减少卷积层数、通道数，或减小LSTM/Transformer的隐藏单元数。
 5.  **增加数据量**: 收集更多样化的数据。
 
-### Q: 分类精度为什么很低？
-
-A: 分类精度低有以下几个主要原因：
-
-1. **类别数量过多**: 10×10 网格 = 100 个类别，随机猜测基准仅为 1%。
-2. **损失函数忽略空间距离**: `CrossEntropyLoss` 对所有错误预测一视同仁。将 `(0,0)` 预测为 `(1,0)` 与预测为 `(9,9)` 受到相同惩罚，模型无法感知"距离"的概念。
-3. **每类样本量有限**: 每位置约 400 个样本（时间步 15、步长 2 滑窗后），100 类分类任务数据量不足。
-4. **位置定位本质是连续空间问题**: 分类方法将连续空间强行离散化，丢失了相邻位置 CSI 相似的先验知识。
-
-**解决方案**: 切换到回归模式 `--task regression`，直接预测坐标并用欧氏距离衡量误差。
-
-### Q: 为什么选择分类而非回归来定位?
-A: 本项目同时支持两种模式，各有优劣：
-
--   **分类模式** (`--task classification`): 将每个位置视为独立类别，适合位置点少（≤30 个）、数据量充足的场景。优点是直观（准确率），缺点是忽略空间关系，类别多时精度下降明显。
--   **回归模式** (`--task regression`): 直接预测 `(x,y)` 坐标，适合位置点多、需要亚格点精度的场景。优点是利用空间连续性，误差指标直观（平均距离误差）。
-
-**一般建议**: 如果分类精度低于 50%，建议切换到回归模式。
-
-### Q: 如何改进模型性能?
+### Q: 如何改进定位精度?
 A:
 1.  **数据质量与数量**:
     -   确保CSI数据质量高，噪声低。
-    -   增加训练数据量，覆盖更多样化的环境条件和位置。特别是在模型易混淆的位置点增加样本。
-2.  **特征工程**:
+    -   增加训练数据量，覆盖更多样化的环境条件和位置。
+2.  **损失函数调整**: 尝试不同的 `--reg_loss` 选项，观察对误差分布的影响。
+3.  **时间步长调整**: 增大 `--time_step` 可让模型利用更多历史信息；减小 `--stride` 可增加训练样本数量（但会增加相邻样本间的重叠度）。
+4.  **特征工程**:
     -   探索除了幅度和相位之外的其他CSI衍生特征。
     -   尝试不同的归一化或滤波方法。
-3.  **模型架构调整**:
+5.  **模型架构调整**:
     -   对于CNN部分，尝试不同的卷积核大小、步长、层数。
-    -   对于LSTM/Transformer，调整隐藏单元数、层数、注意力头数等。
-    -   考虑引入注意力机制到CNN或LSTM结构中。
-4.  **超参数优化**: 系统地搜索最佳的学习率、批大小、优化器参数等。
-5.  **多天线数据融合策略**: 当前是将多天线数据作为独立通道堆叠。可以研究更复杂的融合方法。
-6.  **后处理**: 对模型的分类输出进行平滑处理或结合运动模型。
+    -   对于LSTM，调整隐藏单元数和层数。
+    -   对于Transformer，调整 `nhead`, `num_encoder_layers`, `dim_feedforward`。
+6.  **超参数优化**: 系统地搜索最佳的学习率、批大小等。
+
+### Q: 回归模型的误差指标如何解读?
+A:
+-   **平均/中位距离误差**: 单位为"网格单元"，即坐标系中的一格距离。如果您的网格间距为1米，则误差单位也为米。
+-   **命中率 (within N 网格单元)**: 表示预测误差在 N 个网格单元以内的样本占总样本的百分比。within-1 命中率越高，说明精细定位能力越强。
+-   **误差CDF图**: 横轴为距离误差，纵轴为累积概率。曲线越靠左上角，模型整体性能越好。
+-   **预测散点图**: 横轴为真实坐标，纵轴为预测坐标，理想情况下散点沿 y=x 对角线分布。

--- a/base_model.py
+++ b/base_model.py
@@ -1,0 +1,174 @@
+# 作者：程序员石磊，盗用卖钱可耻，在github即可搜到
+"""
+CSIBaseModel — shared regression training / evaluation / visualization logic
+for all three architectures (CNN, CNN-LSTM, CNN-Transformer).
+
+Each concrete model only needs to:
+  1. Inherit from CSIBaseModel
+  2. Build backbone layers in __init__, then call _init_regression_head(feature_dim)
+  3. Implement _extract_features(x) -> Tensor(batch, feature_dim)
+  4. Implement forward(x) -> Tensor(batch, 2)  [predicts (x, y) coordinates]
+
+Supported regression losses (--reg_loss)
+-----------------------------------------
+smooth_l1  Huber loss — robust to outliers, default choice
+mse        Mean Squared Error — penalises large errors more heavily
+mae        Mean Absolute Error (L1) — most robust to outliers
+"""
+
+import os
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import pytorch_lightning as pl
+import matplotlib.pyplot as plt
+
+
+class CSIBaseModel(pl.LightningModule):
+    """Base class — do NOT instantiate directly."""
+
+    # Subclasses set this for result directory naming
+    model_name: str = 'base'
+
+    # ------------------------------------------------------------------
+    # Initialisation helper
+    # ------------------------------------------------------------------
+
+    def _init_regression_head(self, feature_dim: int):
+        """
+        Call at the end of each subclass __init__ after backbone layers.
+        Creates the regression output head and test accumulators.
+        """
+        self.fc_reg = nn.Linear(feature_dim, 2)   # outputs (x, y)
+
+        self.test_reg_preds:   list = []
+        self.test_reg_targets: list = []
+
+    # ------------------------------------------------------------------
+    # Loss helper
+    # ------------------------------------------------------------------
+
+    def _reg_loss_fn(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        loss_type = self.hparams.reg_loss
+        if loss_type == 'mse':
+            return F.mse_loss(pred, target)
+        if loss_type == 'mae':
+            return F.l1_loss(pred, target)
+        return F.smooth_l1_loss(pred, target)   # default: smooth_l1
+
+    # ------------------------------------------------------------------
+    # Shared step logic
+    # ------------------------------------------------------------------
+
+    def _step(self, batch, stage: str):
+        data, targets = batch          # targets: float32 (batch, 2) = [x, y]
+        preds = self(data)             # (batch, 2)
+        loss  = self._reg_loss_fn(preds, targets)
+
+        with torch.no_grad():
+            dist = torch.sqrt(((preds - targets) ** 2).sum(dim=1)).mean()
+
+        self.log(f'{stage}_loss', loss, on_epoch=True, prog_bar=True,  logger=True, on_step=False)
+        self.log(f'{stage}_dist', dist, on_epoch=True, prog_bar=True,  logger=True, on_step=False)
+        return loss
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
+        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+            optimizer,
+            mode='min',
+            factor=self.hparams.lr_factor,
+            patience=self.hparams.lr_patience,
+            eps=self.hparams.lr_eps,
+        )
+        return {'optimizer': optimizer,
+                'lr_scheduler': {'scheduler': scheduler, 'monitor': 'val_loss'}}
+
+    def training_step(self, batch, batch_idx):
+        return self._step(batch, 'train')
+
+    def validation_step(self, batch, batch_idx):
+        return self._step(batch, 'val')
+
+    # ------------------------------------------------------------------
+    # Test step — accumulate predictions
+    # ------------------------------------------------------------------
+
+    def test_step(self, batch, batch_idx):
+        data, targets = batch
+        preds = self(data)
+        loss  = self._step(batch, 'test')
+
+        self.test_reg_preds.extend(preds.detach().cpu().numpy())
+        self.test_reg_targets.extend(targets.cpu().numpy())
+        return loss
+
+    # ------------------------------------------------------------------
+    # Test epoch end — metrics + plots
+    # ------------------------------------------------------------------
+
+    def on_test_epoch_end(self):
+        if not self.test_reg_preds:
+            return
+
+        log_dir = os.path.join(os.getcwd(), 'results', f'{self.model_name}_results')
+        os.makedirs(log_dir, exist_ok=True)
+        self._report_regression(log_dir)
+
+        self.test_reg_preds   = []
+        self.test_reg_targets = []
+        print(f'{self.__class__.__name__} on_test_epoch_end completed')
+
+    # ------------------------------------------------------------------
+    # Regression reporting
+    # ------------------------------------------------------------------
+
+    def _report_regression(self, log_dir: str):
+        preds   = np.array(self.test_reg_preds)    # (N, 2)
+        targets = np.array(self.test_reg_targets)  # (N, 2)
+        dists   = np.sqrt(((preds - targets) ** 2).sum(axis=1))
+
+        mean_d   = dists.mean()
+        median_d = np.median(dists)
+        w1 = (dists <= 1.0).mean() * 100
+        w2 = (dists <= 2.0).mean() * 100
+        w3 = (dists <= 3.0).mean() * 100
+
+        print(f'\n{self.__class__.__name__} Regression Results:')
+        print(f'  Mean Distance Error   : {mean_d:.4f} grid units')
+        print(f'  Median Distance Error : {median_d:.4f} grid units')
+        print(f'  Within 1 unit  : {w1:.1f}%')
+        print(f'  Within 2 units : {w2:.1f}%')
+        print(f'  Within 3 units : {w3:.1f}%')
+
+        # CDF plot
+        sd  = np.sort(dists)
+        cdf = np.arange(1, len(sd) + 1) / len(sd)
+        fig, ax = plt.subplots(figsize=(8, 5))
+        ax.plot(sd, cdf, linewidth=2)
+        ax.axvline(mean_d,   color='r', linestyle='--', label=f'Mean {mean_d:.2f}')
+        ax.axvline(median_d, color='g', linestyle='--', label=f'Median {median_d:.2f}')
+        ax.set_xlabel('Distance Error (grid units)')
+        ax.set_ylabel('CDF')
+        ax.set_title(f'{self.__class__.__name__} — CDF of Position Error')
+        ax.legend()
+        ax.grid(True, alpha=0.3)
+        fig.tight_layout()
+        fig.savefig(os.path.join(log_dir, f'{self.model_name}_regression_cdf.png'), dpi=150)
+        plt.close(fig)
+
+        # Scatter: true vs predicted
+        fig, ax = plt.subplots(figsize=(8, 8))
+        ax.scatter(targets[:, 0], targets[:, 1], c='steelblue', alpha=0.3, s=10, label='True')
+        ax.scatter(preds[:, 0],   preds[:, 1],   c='tomato',    alpha=0.3, s=10, label='Predicted')
+        ax.set_xlabel('X coordinate (grid units)')
+        ax.set_ylabel('Y coordinate (grid units)')
+        ax.set_title(f'{self.__class__.__name__} — True vs Predicted Locations\n'
+                     f'Mean Error: {mean_d:.3f}  Median: {median_d:.3f}')
+        ax.legend()
+        fig.tight_layout()
+        fig.savefig(os.path.join(log_dir, f'{self.model_name}_regression_scatter.png'), dpi=150)
+        plt.close(fig)
+
+        print(f'  Plots saved to {log_dir}')

--- a/cnn_lstm_net_model.py
+++ b/cnn_lstm_net_model.py
@@ -1,218 +1,63 @@
 # 作者：程序员石磊，盗用卖钱可耻，在github即可搜到
 import torch
-import pytorch_lightning as pl
-from torch import nn
-from torch.nn import functional as F
-import matplotlib.pyplot as plt
-import numpy as np
-import os
-from sklearn.metrics import accuracy_score, confusion_matrix
+import torch.nn as nn
+import torch.nn.functional as F
+from base_model import CSIBaseModel
 
 
-class CNN_LSTM_Net(pl.LightningModule):
-    def __init__(self, lr, lr_factor, lr_patience, lr_eps, num_classes=0,
-                 time_step=15, num_subcarriers=30, task='classification'):
+class CNN_LSTM_Net(CSIBaseModel):
+    """
+    CNN + LSTM model for WiFi CSI indoor positioning (regression).
+
+    Architecture
+    ------------
+    Input  (batch, 6, time_step, num_subcarriers)
+      → Conv2d(6→18, k=5, p=2) + BN + ReLU   ×3  [spatial dims preserved]
+      → Reshape → (batch, time_step, 18 · num_subcarriers)
+      → LSTM(hidden=100, batch_first=True)  → last time-step
+      → fc_reg: FC(100 → 2)   [predicts (x, y)]
+    """
+
+    model_name = 'cnn_lstm'
+
+    def __init__(
+        self,
+        lr: float,
+        lr_factor: float,
+        lr_patience: int,
+        lr_eps: float,
+        num_classes: int = 0,          # unused; kept for API compat
+        time_step: int = 15,
+        num_subcarriers: int = 30,
+        reg_loss: str = 'smooth_l1',   # 'smooth_l1' | 'mse' | 'mae'
+    ):
         super().__init__()
         self.save_hyperparameters()
 
-        self.test_preds = []
-        self.test_targets = []
-        self.printed_input_shape = False
+        self.conv1 = nn.Conv2d(6, 18, kernel_size=5, padding=2)
+        self.bn1   = nn.BatchNorm2d(18)
+        self.conv2 = nn.Conv2d(18, 18, kernel_size=5, padding=2)
+        self.bn2   = nn.BatchNorm2d(18)
+        self.conv3 = nn.Conv2d(18, 18, kernel_size=5, padding=2)
+        self.bn3   = nn.BatchNorm2d(18)
 
-        # CNN layers (preserve HxW with padding=2)
-        self.conv1 = nn.Conv2d(in_channels=6, out_channels=18, kernel_size=5, padding=2)
-        self.bn1 = nn.BatchNorm2d(num_features=18)
-        self.conv2 = nn.Conv2d(in_channels=18, out_channels=18, kernel_size=5, padding=2)
-        self.bn2 = nn.BatchNorm2d(num_features=18)
-        self.conv3 = nn.Conv2d(in_channels=18, out_channels=18, kernel_size=5, padding=2)
-        self.bn3 = nn.BatchNorm2d(num_features=18)
+        self.lstm = nn.LSTM(
+            input_size=18 * num_subcarriers,
+            hidden_size=100,
+            batch_first=True,
+        )
 
-        # LSTM: (batch, time_step, 18 * num_subcarriers)
-        lstm_input_features = 18 * self.hparams.num_subcarriers
-        self.lstm = nn.LSTM(input_size=lstm_input_features, hidden_size=100, batch_first=True)
+        self._init_regression_head(feature_dim=100)
 
-        # Output: 2 neurons for regression (x,y), num_classes for classification
-        out_features = 2 if self.hparams.task == 'regression' else self.hparams.num_classes
-        self.fc = nn.Linear(100, out_features)
-
-    def forward(self, x):
-        if not self.printed_input_shape and hasattr(x, 'ndim') and x.ndim == 4:
-            print(f"CNN_LSTM_Net input shape: {x.shape}")
-            self.printed_input_shape = True
-
+    def _extract_features(self, x: torch.Tensor) -> torch.Tensor:
         x = F.relu(self.bn1(self.conv1(x)))
         x = F.relu(self.bn2(self.conv2(x)))
         x = F.relu(self.bn3(self.conv3(x)))
-
-        # (batch, 18, time_step, num_subcarriers) -> (batch, time_step, 18 * num_subcarriers)
+        # (batch, 18, T, S) → (batch, T, 18·S)
         x = x.permute(0, 2, 1, 3).contiguous()
         x = x.view(x.size(0), x.size(1), -1)
-
         x, _ = self.lstm(x)
-        x = x[:, -1, :]  # last time step
-        x = self.fc(x)
-        return x
+        return x[:, -1, :]    # last time-step
 
-    def _compute_loss(self, output, targets):
-        if self.hparams.task == 'regression':
-            return F.smooth_l1_loss(output, targets)
-        else:
-            return F.cross_entropy(output, targets)
-
-    def configure_optimizers(self):
-        optimizer = torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
-        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-            optimizer,
-            mode='min',
-            factor=self.hparams.lr_factor,
-            patience=self.hparams.lr_patience,
-            eps=self.hparams.lr_eps
-        )
-        return {
-            'optimizer': optimizer,
-            'lr_scheduler': {'scheduler': scheduler, 'monitor': 'val_loss'},
-        }
-
-    def training_step(self, batch, batch_idx):
-        data, targets = batch
-        output = self(data)
-        loss = self._compute_loss(output, targets)
-
-        if self.hparams.task == 'regression':
-            dist = torch.sqrt(((output - targets) ** 2).sum(dim=1)).mean()
-            self.log('train_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('train_dist', dist, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        else:
-            preds = torch.argmax(output, dim=1)
-            acc = (preds == targets).float().mean()
-            self.log('train_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('train_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        return loss
-
-    def validation_step(self, batch, batch_idx):
-        data, targets = batch
-        output = self(data)
-        loss = self._compute_loss(output, targets)
-
-        if self.hparams.task == 'regression':
-            dist = torch.sqrt(((output - targets) ** 2).sum(dim=1)).mean()
-            self.log('val_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('val_dist', dist, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        else:
-            preds = torch.argmax(output, dim=1)
-            acc = (preds == targets).float().mean()
-            self.log('val_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('val_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        return loss
-
-    def test_step(self, batch, batch_idx):
-        data, targets = batch
-        output = self(data)
-        loss = self._compute_loss(output, targets)
-        self.log('test_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-
-        if self.hparams.task == 'regression':
-            self.test_preds.extend(output.cpu().detach().numpy())
-            self.test_targets.extend(targets.cpu().numpy())
-        else:
-            preds = torch.argmax(output, dim=1)
-            acc = (preds == targets).float().mean()
-            self.log('test_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.test_preds.extend(preds.cpu().numpy())
-            self.test_targets.extend(targets.cpu().numpy())
-        return loss
-
-    def on_test_epoch_end(self):
-        if not self.test_targets or not self.test_preds:
-            self.test_preds = []
-            self.test_targets = []
-            return
-
-        log_dir = os.path.join(os.getcwd(), "results", "cnn_lstm_results")
-        os.makedirs(log_dir, exist_ok=True)
-
-        if self.hparams.task == 'regression':
-            preds = np.array(self.test_preds)    # shape (N, 2)
-            targets = np.array(self.test_targets)  # shape (N, 2)
-            distances = np.sqrt(((preds - targets) ** 2).sum(axis=1))
-            mean_dist = distances.mean()
-            median_dist = np.median(distances)
-            within_1 = (distances <= 1.0).mean() * 100
-            within_2 = (distances <= 2.0).mean() * 100
-            within_3 = (distances <= 3.0).mean() * 100
-
-            print(f"CNN_LSTM_Net Regression Results:")
-            print(f"  Mean Distance Error:   {mean_dist:.4f} units")
-            print(f"  Median Distance Error: {median_dist:.4f} units")
-            print(f"  Within 1 unit:  {within_1:.1f}%")
-            print(f"  Within 2 units: {within_2:.1f}%")
-            print(f"  Within 3 units: {within_3:.1f}%")
-
-            sorted_dist = np.sort(distances)
-            cdf = np.arange(1, len(sorted_dist) + 1) / len(sorted_dist)
-            plt.figure(figsize=(8, 5))
-            plt.plot(sorted_dist, cdf)
-            plt.xlabel('Distance Error (grid units)')
-            plt.ylabel('CDF')
-            plt.title(f'CNN_LSTM_Net Regression - CDF of Distance Error\nMean: {mean_dist:.3f}, Median: {median_dist:.3f}')
-            plt.grid(True)
-            plt.tight_layout()
-            plt.savefig(os.path.join(log_dir, 'cnn_lstm_net_regression_cdf.png'), dpi=300)
-            plt.close()
-
-            plt.figure(figsize=(8, 8))
-            plt.scatter(targets[:, 0], targets[:, 1], c='blue', alpha=0.3, s=10, label='True')
-            plt.scatter(preds[:, 0], preds[:, 1], c='red', alpha=0.3, s=10, label='Predicted')
-            plt.xlabel('X coordinate')
-            plt.ylabel('Y coordinate')
-            plt.title('CNN_LSTM_Net Regression: True vs Predicted Locations')
-            plt.legend()
-            plt.tight_layout()
-            plt.savefig(os.path.join(log_dir, 'cnn_lstm_net_regression_scatter.png'), dpi=300)
-            plt.close()
-            print(f"CNN_LSTM_Net regression plots saved to {log_dir}")
-        else:
-            accuracy = accuracy_score(self.test_targets, self.test_preds)
-            conf_matrix = confusion_matrix(self.test_targets, self.test_preds)
-
-            print(f"CNN_LSTM_Net Test Accuracy: {accuracy:.4f}")
-            print("CNN_LSTM_Net Confusion Matrix:")
-            print(conf_matrix)
-
-            datamodule = getattr(self.trainer, 'datamodule', None)
-            if datamodule and hasattr(datamodule, 'dataset') and \
-               hasattr(datamodule.dataset, 'class_to_location'):
-                class_to_location = datamodule.dataset.class_to_location
-                classes = sorted(list(class_to_location.keys()))
-                location_labels = [f"({class_to_location[c][0]},{class_to_location[c][1]})" for c in classes]
-
-                fig_width = max(12, len(classes) * 0.6)
-                fig_height = max(10, len(classes) * 0.5)
-                plt.figure(figsize=(fig_width, fig_height))
-                plt.imshow(conf_matrix, cmap='Blues')
-                plt.colorbar()
-                plt.title(f'CNN_LSTM_Net Classification Confusion Matrix\nAccuracy: {accuracy:.4f}')
-                plt.xlabel('Predicted Location')
-                plt.ylabel('True Location')
-                tick_positions = np.arange(len(classes))
-                plt.xticks(tick_positions, location_labels, rotation=90, fontsize=8)
-                plt.yticks(tick_positions, location_labels, fontsize=8)
-                for i in range(conf_matrix.shape[0]):
-                    for j in range(conf_matrix.shape[1]):
-                        plt.text(j, i, str(conf_matrix[i, j]),
-                                 ha="center", va="center",
-                                 color="white" if conf_matrix[i, j] > conf_matrix.max() / 2 else "black")
-                plt.tight_layout()
-                save_path = os.path.join(log_dir, 'cnn_lstm_net_confusion_matrix.png')
-                try:
-                    plt.savefig(save_path, dpi=300)
-                    print(f"CNN_LSTM_Net Confusion matrix saved to {save_path}")
-                except Exception as e:
-                    print(f"Error saving CNN_LSTM_Net confusion matrix: {e}")
-                plt.close()
-            else:
-                print("Warning: class_to_location mapping not available. Skipping confusion matrix.")
-
-        self.test_preds = []
-        self.test_targets = []
-        print('CNN_LSTM_Net on_test_epoch_end completed')
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc_reg(self._extract_features(x))

--- a/cnn_net_model.py
+++ b/cnn_net_model.py
@@ -1,222 +1,66 @@
 # 作者：程序员石磊，盗用卖钱可耻，在github即可搜到
 import torch
-import pytorch_lightning as pl
-from torch import nn
-from torch.nn import functional as F
-import matplotlib.pyplot as plt
-import numpy as np
-import os
-from sklearn.metrics import accuracy_score, confusion_matrix
+import torch.nn as nn
+import torch.nn.functional as F
+from base_model import CSIBaseModel
 
 
-class CNN_Net(pl.LightningModule):
-    def __init__(self, lr, lr_factor, lr_patience, lr_eps, num_classes=0,
-                 time_step=15, num_subcarriers=30, task='classification'):
+class CNN_Net(CSIBaseModel):
+    """
+    Pure CNN model for WiFi CSI indoor positioning (regression).
+
+    Architecture
+    ------------
+    Input  (batch, 6, time_step, num_subcarriers)
+      → Conv2d(6→18, k=5, p=2) + BN + ReLU   ×3  [spatial dims preserved]
+      → Flatten
+      → FC(18·T·S → 1024) + BN + ReLU + Dropout(0.5)
+      → FC(1024 → 512)    + BN + ReLU + Dropout(0.3)
+      → fc_reg: FC(512 → 2)   [predicts (x, y)]
+    """
+
+    model_name = 'cnn'
+
+    def __init__(
+        self,
+        lr: float,
+        lr_factor: float,
+        lr_patience: int,
+        lr_eps: float,
+        num_classes: int = 0,          # unused for regression; kept for API compat
+        time_step: int = 15,
+        num_subcarriers: int = 30,
+        reg_loss: str = 'smooth_l1',   # 'smooth_l1' | 'mse' | 'mae'
+    ):
         super().__init__()
         self.save_hyperparameters()
 
-        self.test_preds = []
-        self.test_targets = []
-        self.printed_input_shape = False
+        self.conv1 = nn.Conv2d(6, 18, kernel_size=5, padding=2)
+        self.bn1   = nn.BatchNorm2d(18)
+        self.conv2 = nn.Conv2d(18, 18, kernel_size=5, padding=2)
+        self.bn2   = nn.BatchNorm2d(18)
+        self.conv3 = nn.Conv2d(18, 18, kernel_size=5, padding=2)
+        self.bn3   = nn.BatchNorm2d(18)
 
-        self.conv1 = nn.Conv2d(in_channels=6, out_channels=18, kernel_size=5, padding=2)
-        self.bn1 = nn.BatchNorm2d(num_features=18)
-        self.conv2 = nn.Conv2d(in_channels=18, out_channels=18, kernel_size=5, padding=2)
-        self.bn2 = nn.BatchNorm2d(num_features=18)
-        self.conv3 = nn.Conv2d(in_channels=18, out_channels=18, kernel_size=5, padding=2)
-        self.bn3 = nn.BatchNorm2d(num_features=18)
+        feat = 18 * time_step * num_subcarriers   # dims preserved by padding
 
-        conv_output_size = 18 * self.hparams.time_step * self.hparams.num_subcarriers
-
-        self.fc1 = nn.Linear(conv_output_size, 1024)
-        self.bn4 = nn.BatchNorm1d(num_features=1024)
+        self.fc1      = nn.Linear(feat, 1024)
+        self.bn4      = nn.BatchNorm1d(1024)
         self.dropout1 = nn.Dropout(0.5)
-        self.fc2 = nn.Linear(1024, 512)
-        self.bn5 = nn.BatchNorm1d(num_features=512)
+        self.fc2      = nn.Linear(1024, 512)
+        self.bn5      = nn.BatchNorm1d(512)
         self.dropout2 = nn.Dropout(0.3)
 
-        # Output: 2 neurons for regression (x,y), num_classes for classification
-        out_features = 2 if self.hparams.task == 'regression' else self.hparams.num_classes
-        self.fc3 = nn.Linear(512, out_features)
+        self._init_regression_head(feature_dim=512)
 
-    def forward(self, x):
-        if not self.printed_input_shape and x.ndim == 4:
-            print(f"CNN_Net input shape: {x.shape}")
-            self.printed_input_shape = True
-
+    def _extract_features(self, x: torch.Tensor) -> torch.Tensor:
         x = F.relu(self.bn1(self.conv1(x)))
         x = F.relu(self.bn2(self.conv2(x)))
         x = F.relu(self.bn3(self.conv3(x)))
         x = x.view(x.size(0), -1)
-        x = F.relu(self.bn4(self.fc1(x)))
-        x = self.dropout1(x)
-        x = F.relu(self.bn5(self.fc2(x)))
-        x = self.dropout2(x)
-        x = self.fc3(x)
+        x = self.dropout1(F.relu(self.bn4(self.fc1(x))))
+        x = self.dropout2(F.relu(self.bn5(self.fc2(x))))
         return x
 
-    def _compute_loss(self, output, targets):
-        if self.hparams.task == 'regression':
-            return F.smooth_l1_loss(output, targets)
-        else:
-            return F.cross_entropy(output, targets)
-
-    def configure_optimizers(self):
-        optimizer = torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
-        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-            optimizer,
-            mode='min',
-            factor=self.hparams.lr_factor,
-            patience=self.hparams.lr_patience,
-            eps=self.hparams.lr_eps
-        )
-        return {
-            'optimizer': optimizer,
-            'lr_scheduler': {'scheduler': scheduler, 'monitor': 'val_loss'},
-        }
-
-    def training_step(self, batch, batch_idx):
-        data, targets = batch
-        output = self(data)
-        loss = self._compute_loss(output, targets)
-
-        if self.hparams.task == 'regression':
-            dist = torch.sqrt(((output - targets) ** 2).sum(dim=1)).mean()
-            self.log('train_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('train_dist', dist, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        else:
-            preds = torch.argmax(output, dim=1)
-            acc = (preds == targets).float().mean()
-            self.log('train_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('train_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        return loss
-
-    def validation_step(self, batch, batch_idx):
-        data, targets = batch
-        output = self(data)
-        loss = self._compute_loss(output, targets)
-
-        if self.hparams.task == 'regression':
-            dist = torch.sqrt(((output - targets) ** 2).sum(dim=1)).mean()
-            self.log('val_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('val_dist', dist, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        else:
-            preds = torch.argmax(output, dim=1)
-            acc = (preds == targets).float().mean()
-            self.log('val_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('val_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        return loss
-
-    def test_step(self, batch, batch_idx):
-        data, targets = batch
-        output = self(data)
-        loss = self._compute_loss(output, targets)
-        self.log('test_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-
-        if self.hparams.task == 'regression':
-            self.test_preds.extend(output.cpu().detach().numpy())
-            self.test_targets.extend(targets.cpu().numpy())
-        else:
-            preds = torch.argmax(output, dim=1)
-            acc = (preds == targets).float().mean()
-            self.log('test_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.test_preds.extend(preds.cpu().numpy())
-            self.test_targets.extend(targets.cpu().numpy())
-        return loss
-
-    def on_test_epoch_end(self):
-        if not self.test_targets or not self.test_preds:
-            self.test_preds = []
-            self.test_targets = []
-            return
-
-        log_dir = os.path.join(os.getcwd(), "results", "cnn_results")
-        os.makedirs(log_dir, exist_ok=True)
-
-        if self.hparams.task == 'regression':
-            preds = np.array(self.test_preds)    # shape (N, 2)
-            targets = np.array(self.test_targets)  # shape (N, 2)
-            distances = np.sqrt(((preds - targets) ** 2).sum(axis=1))
-            mean_dist = distances.mean()
-            median_dist = np.median(distances)
-            within_1 = (distances <= 1.0).mean() * 100
-            within_2 = (distances <= 2.0).mean() * 100
-            within_3 = (distances <= 3.0).mean() * 100
-
-            print(f"CNN_Net Regression Results:")
-            print(f"  Mean Distance Error:   {mean_dist:.4f} units")
-            print(f"  Median Distance Error: {median_dist:.4f} units")
-            print(f"  Within 1 unit:  {within_1:.1f}%")
-            print(f"  Within 2 units: {within_2:.1f}%")
-            print(f"  Within 3 units: {within_3:.1f}%")
-
-            # CDF plot
-            sorted_dist = np.sort(distances)
-            cdf = np.arange(1, len(sorted_dist) + 1) / len(sorted_dist)
-            plt.figure(figsize=(8, 5))
-            plt.plot(sorted_dist, cdf)
-            plt.xlabel('Distance Error (grid units)')
-            plt.ylabel('CDF')
-            plt.title(f'CNN_Net Regression - CDF of Distance Error\nMean: {mean_dist:.3f}, Median: {median_dist:.3f}')
-            plt.grid(True)
-            plt.tight_layout()
-            plt.savefig(os.path.join(log_dir, 'cnn_net_regression_cdf.png'), dpi=300)
-            plt.close()
-
-            # Scatter: true vs predicted locations
-            plt.figure(figsize=(8, 8))
-            plt.scatter(targets[:, 0], targets[:, 1], c='blue', alpha=0.3, s=10, label='True')
-            plt.scatter(preds[:, 0], preds[:, 1], c='red', alpha=0.3, s=10, label='Predicted')
-            plt.xlabel('X coordinate')
-            plt.ylabel('Y coordinate')
-            plt.title('CNN_Net Regression: True vs Predicted Locations')
-            plt.legend()
-            plt.tight_layout()
-            plt.savefig(os.path.join(log_dir, 'cnn_net_regression_scatter.png'), dpi=300)
-            plt.close()
-            print(f"CNN_Net regression plots saved to {log_dir}")
-        else:
-            accuracy = accuracy_score(self.test_targets, self.test_preds)
-            conf_matrix = confusion_matrix(self.test_targets, self.test_preds)
-
-            print(f"CNN_Net Test Accuracy: {accuracy:.4f}")
-            print("CNN_Net Confusion Matrix:")
-            print(conf_matrix)
-
-            datamodule = getattr(self.trainer, 'datamodule', None)
-            if datamodule and hasattr(datamodule, 'dataset') and \
-               hasattr(datamodule.dataset, 'class_to_location'):
-                class_to_location = datamodule.dataset.class_to_location
-                classes = sorted(list(class_to_location.keys()))
-                location_labels = [f"({class_to_location[c][0]},{class_to_location[c][1]})" for c in classes]
-
-                fig_width = max(12, len(classes) * 0.6)
-                fig_height = max(10, len(classes) * 0.5)
-                plt.figure(figsize=(fig_width, fig_height))
-                plt.imshow(conf_matrix, cmap='Blues')
-                plt.colorbar()
-                plt.title(f'CNN_Net Classification Confusion Matrix\nAccuracy: {accuracy:.4f}')
-                plt.xlabel('Predicted Location')
-                plt.ylabel('True Location')
-                tick_positions = np.arange(len(classes))
-                plt.xticks(tick_positions, location_labels, rotation=90, fontsize=8)
-                plt.yticks(tick_positions, location_labels, fontsize=8)
-                for i in range(conf_matrix.shape[0]):
-                    for j in range(conf_matrix.shape[1]):
-                        plt.text(j, i, str(conf_matrix[i, j]),
-                                 ha="center", va="center",
-                                 color="white" if conf_matrix[i, j] > conf_matrix.max() / 2 else "black")
-                plt.tight_layout()
-                save_path = os.path.join(log_dir, 'cnn_net_confusion_matrix.png')
-                try:
-                    plt.savefig(save_path, dpi=300)
-                    print(f"CNN_Net Confusion matrix saved to {save_path}")
-                except Exception as e:
-                    print(f"Error saving confusion matrix: {e}")
-                plt.close()
-            else:
-                print("Warning: class_to_location mapping not available. Skipping confusion matrix.")
-
-        self.test_preds = []
-        self.test_targets = []
-        print('CNN_Net on_test_epoch_end completed')
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc_reg(self._extract_features(x))

--- a/cnn_transformer_model.py
+++ b/cnn_transformer_model.py
@@ -1,238 +1,94 @@
 # 作者：程序员石磊，盗用卖钱可耻，在github即可搜到
 import torch
-import pytorch_lightning as pl
-from torch import nn
-from torch.nn import functional as F
-import matplotlib.pyplot as plt
-import numpy as np
-import os
-from sklearn.metrics import accuracy_score, confusion_matrix
+import torch.nn as nn
+import torch.nn.functional as F
+from base_model import CSIBaseModel
 
 
-class CNN_Transformer_Net(pl.LightningModule):
-    def __init__(self, lr, lr_factor, lr_patience, lr_eps, num_classes,
-                 time_step, num_subcarriers, d_model_override=None,
-                 nhead=4, num_encoder_layers=3, dim_feedforward=256,
-                 task='classification'):
+class CNN_Transformer_Net(CSIBaseModel):
+    """
+    CNN + Transformer model for WiFi CSI indoor positioning (regression).
+
+    Architecture
+    ------------
+    Input  (batch, 6, time_step, num_subcarriers)
+      → Conv2d(6→16, k=3, p=1) + BN + ReLU + MaxPool(2,2)
+          → (batch, 16, T/2, S/2)
+      → Conv2d(16→32, k=3, p=1) + BN + ReLU + MaxPool(2,2)
+          → (batch, 32, T/4, S/4)
+      → Reshape → (batch, T/4, 32·S/4)   [sequence for Transformer]
+      → TransformerEncoder(d_model=32·S/4, nhead, layers, ff_dim)
+      → First token → fc_reg: FC(d_model → 2)   [predicts (x, y)]
+
+    Notes
+    -----
+    - With default time_step=15, num_subcarriers=30:
+        after two MaxPool(2,2): height = floor(15/2/2) = 3,
+                                width  = floor(30/2/2) = 7
+        d_model = 32 * 7 = 224  (divisible by nhead=4 ✓)
+    - d_model must be divisible by nhead; adjust nhead accordingly.
+    """
+
+    model_name = 'cnn_transformer'
+
+    def __init__(
+        self,
+        lr: float,
+        lr_factor: float,
+        lr_patience: int,
+        lr_eps: float,
+        num_classes: int = 0,           # unused; kept for API compat
+        time_step: int = 15,
+        num_subcarriers: int = 30,
+        reg_loss: str = 'smooth_l1',    # 'smooth_l1' | 'mse' | 'mae'
+        nhead: int = 4,
+        num_encoder_layers: int = 3,
+        dim_feedforward: int = 256,
+    ):
         super().__init__()
         self.save_hyperparameters()
 
-        self.test_preds = []
-        self.test_targets = []
-        self.printed_input_shape = False
-
-        # CNN Backbone
-        self.conv1 = nn.Conv2d(in_channels=6, out_channels=16, kernel_size=3, padding=1)
-        self.bn1 = nn.BatchNorm2d(16)
-        self.relu1 = nn.ReLU()
+        # ---- CNN backbone ----
+        self.conv1 = nn.Conv2d(6,  16, kernel_size=3, padding=1)
+        self.bn1   = nn.BatchNorm2d(16)
         self.pool1 = nn.MaxPool2d(kernel_size=2, stride=2)
 
-        self.conv2 = nn.Conv2d(in_channels=16, out_channels=32, kernel_size=3, padding=1)
-        self.bn2 = nn.BatchNorm2d(32)
-        self.relu2 = nn.ReLU()
+        self.conv2 = nn.Conv2d(16, 32, kernel_size=3, padding=1)
+        self.bn2   = nn.BatchNorm2d(32)
         self.pool2 = nn.MaxPool2d(kernel_size=2, stride=2)
 
-        self.cnn_out_height = self.hparams.time_step // 4
-        self.cnn_out_width = self.hparams.num_subcarriers // 4
+        # After two MaxPool(2,2): floor(dim / 4)
+        self._cnn_h = time_step      // 4   # sequence length for Transformer
+        self._cnn_w = num_subcarriers // 4   # features per token
+        d_model = 32 * self._cnn_w
 
-        if d_model_override is not None:
-            self.d_model = d_model_override
-        else:
-            self.d_model = 32 * self.cnn_out_width
+        if d_model % nhead != 0:
+            raise ValueError(
+                f"d_model ({d_model}) must be divisible by nhead ({nhead}). "
+                f"Adjust num_subcarriers or nhead."
+            )
 
-        if self.d_model % self.hparams.nhead != 0:
-            raise ValueError(f"d_model ({self.d_model}) must be divisible by nhead ({self.hparams.nhead})")
-
+        # ---- Transformer encoder ----
         encoder_layer = nn.TransformerEncoderLayer(
-            d_model=self.d_model,
-            nhead=self.hparams.nhead,
-            dim_feedforward=self.hparams.dim_feedforward,
+            d_model=d_model,
+            nhead=nhead,
+            dim_feedforward=dim_feedforward,
             batch_first=True,
-            dropout=0.1
+            dropout=0.1,
         )
-        self.transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=self.hparams.num_encoder_layers)
+        self.transformer_encoder = nn.TransformerEncoder(
+            encoder_layer, num_layers=num_encoder_layers)
 
-        # Output: 2 neurons for regression (x,y), num_classes for classification
-        out_features = 2 if self.hparams.task == 'regression' else self.hparams.num_classes
-        self.fc = nn.Linear(self.d_model, out_features)
+        self._init_regression_head(feature_dim=d_model)
 
-    def forward(self, x):
-        if not self.printed_input_shape and hasattr(x, 'ndim') and x.ndim == 4:
-            print(f"CNN_Transformer_Net input shape: {x.shape}")
-            self.printed_input_shape = True
-
-        x = self.pool1(self.relu1(self.bn1(self.conv1(x))))
-        x = self.pool2(self.relu2(self.bn2(self.conv2(x))))
-
-        # (batch, 32, cnn_out_height, cnn_out_width) -> (batch, cnn_out_height, 32*cnn_out_width)
+    def _extract_features(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.pool1(F.relu(self.bn1(self.conv1(x))))  # (B, 16, T/2, S/2)
+        x = self.pool2(F.relu(self.bn2(self.conv2(x))))  # (B, 32, T/4, S/4)
+        # → (B, seq_len=T/4, d_model=32·S/4)
         x = x.permute(0, 2, 1, 3).contiguous()
-        x = x.reshape(x.size(0), self.cnn_out_height, -1)
-
+        x = x.reshape(x.size(0), self._cnn_h, -1)
         x = self.transformer_encoder(x)
-        x = x[:, 0, :]  # first token
-        x = self.fc(x)
-        return x
+        return x[:, 0, :]    # first token as global representation
 
-    def _compute_loss(self, output, targets):
-        if self.hparams.task == 'regression':
-            return F.smooth_l1_loss(output, targets)
-        else:
-            return F.cross_entropy(output, targets)
-
-    def configure_optimizers(self):
-        optimizer = torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
-        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-            optimizer,
-            mode='min',
-            factor=self.hparams.lr_factor,
-            patience=self.hparams.lr_patience,
-            eps=self.hparams.lr_eps
-        )
-        return {
-            'optimizer': optimizer,
-            'lr_scheduler': {'scheduler': scheduler, 'monitor': 'val_loss'},
-        }
-
-    def training_step(self, batch, batch_idx):
-        data, targets = batch
-        output = self(data)
-        loss = self._compute_loss(output, targets)
-
-        if self.hparams.task == 'regression':
-            dist = torch.sqrt(((output - targets) ** 2).sum(dim=1)).mean()
-            self.log('train_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('train_dist', dist, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        else:
-            preds = torch.argmax(output, dim=1)
-            acc = (preds == targets).float().mean()
-            self.log('train_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('train_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        return loss
-
-    def validation_step(self, batch, batch_idx):
-        data, targets = batch
-        output = self(data)
-        loss = self._compute_loss(output, targets)
-
-        if self.hparams.task == 'regression':
-            dist = torch.sqrt(((output - targets) ** 2).sum(dim=1)).mean()
-            self.log('val_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('val_dist', dist, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        else:
-            preds = torch.argmax(output, dim=1)
-            acc = (preds == targets).float().mean()
-            self.log('val_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.log('val_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        return loss
-
-    def test_step(self, batch, batch_idx):
-        data, targets = batch
-        output = self(data)
-        loss = self._compute_loss(output, targets)
-        self.log('test_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-
-        if self.hparams.task == 'regression':
-            self.test_preds.extend(output.cpu().detach().numpy())
-            self.test_targets.extend(targets.cpu().numpy())
-        else:
-            preds = torch.argmax(output, dim=1)
-            acc = (preds == targets).float().mean()
-            self.log('test_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=True)
-            self.test_preds.extend(preds.cpu().numpy())
-            self.test_targets.extend(targets.cpu().numpy())
-        return loss
-
-    def on_test_epoch_end(self):
-        if not self.test_targets or not self.test_preds:
-            self.test_preds = []
-            self.test_targets = []
-            return
-
-        log_dir = os.path.join(os.getcwd(), "results", "cnn_transformer_results")
-        os.makedirs(log_dir, exist_ok=True)
-
-        if self.hparams.task == 'regression':
-            preds = np.array(self.test_preds)    # shape (N, 2)
-            targets = np.array(self.test_targets)  # shape (N, 2)
-            distances = np.sqrt(((preds - targets) ** 2).sum(axis=1))
-            mean_dist = distances.mean()
-            median_dist = np.median(distances)
-            within_1 = (distances <= 1.0).mean() * 100
-            within_2 = (distances <= 2.0).mean() * 100
-            within_3 = (distances <= 3.0).mean() * 100
-
-            print(f"CNN_Transformer_Net Regression Results:")
-            print(f"  Mean Distance Error:   {mean_dist:.4f} units")
-            print(f"  Median Distance Error: {median_dist:.4f} units")
-            print(f"  Within 1 unit:  {within_1:.1f}%")
-            print(f"  Within 2 units: {within_2:.1f}%")
-            print(f"  Within 3 units: {within_3:.1f}%")
-
-            sorted_dist = np.sort(distances)
-            cdf = np.arange(1, len(sorted_dist) + 1) / len(sorted_dist)
-            plt.figure(figsize=(8, 5))
-            plt.plot(sorted_dist, cdf)
-            plt.xlabel('Distance Error (grid units)')
-            plt.ylabel('CDF')
-            plt.title(f'CNN_Transformer_Net Regression - CDF of Distance Error\nMean: {mean_dist:.3f}, Median: {median_dist:.3f}')
-            plt.grid(True)
-            plt.tight_layout()
-            plt.savefig(os.path.join(log_dir, 'cnn_transformer_net_regression_cdf.png'), dpi=300)
-            plt.close()
-
-            plt.figure(figsize=(8, 8))
-            plt.scatter(targets[:, 0], targets[:, 1], c='blue', alpha=0.3, s=10, label='True')
-            plt.scatter(preds[:, 0], preds[:, 1], c='red', alpha=0.3, s=10, label='Predicted')
-            plt.xlabel('X coordinate')
-            plt.ylabel('Y coordinate')
-            plt.title('CNN_Transformer_Net Regression: True vs Predicted Locations')
-            plt.legend()
-            plt.tight_layout()
-            plt.savefig(os.path.join(log_dir, 'cnn_transformer_net_regression_scatter.png'), dpi=300)
-            plt.close()
-            print(f"CNN_Transformer_Net regression plots saved to {log_dir}")
-        else:
-            accuracy = accuracy_score(self.test_targets, self.test_preds)
-            conf_matrix = confusion_matrix(self.test_targets, self.test_preds)
-
-            print(f"CNN_Transformer_Net Test Accuracy: {accuracy:.4f}")
-            print("CNN_Transformer_Net Confusion Matrix:")
-            print(conf_matrix)
-
-            datamodule = getattr(self.trainer, 'datamodule', None)
-            if datamodule and hasattr(datamodule, 'dataset') and \
-               hasattr(datamodule.dataset, 'class_to_location'):
-                class_to_location = datamodule.dataset.class_to_location
-                classes = sorted(list(class_to_location.keys()))
-                location_labels = [f"({class_to_location[c][0]},{class_to_location[c][1]})" for c in classes]
-
-                fig_width = max(12, len(classes) * 0.6)
-                fig_height = max(10, len(classes) * 0.5)
-                plt.figure(figsize=(fig_width, fig_height))
-                plt.imshow(conf_matrix, cmap='Blues')
-                plt.colorbar()
-                plt.title(f'CNN_Transformer_Net Classification Confusion Matrix\nAccuracy: {accuracy:.4f}')
-                plt.xlabel('Predicted Location')
-                plt.ylabel('True Location')
-                tick_positions = np.arange(len(classes))
-                plt.xticks(tick_positions, location_labels, rotation=90, fontsize=8)
-                plt.yticks(tick_positions, location_labels, fontsize=8)
-                for i in range(conf_matrix.shape[0]):
-                    for j in range(conf_matrix.shape[1]):
-                        plt.text(j, i, str(conf_matrix[i, j]),
-                                 ha="center", va="center",
-                                 color="white" if conf_matrix[i, j] > conf_matrix.max() / 2 else "black")
-                plt.tight_layout()
-                save_path = os.path.join(log_dir, 'cnn_transformer_net_confusion_matrix.png')
-                try:
-                    plt.savefig(save_path, dpi=300)
-                    print(f"CNN_Transformer_Net Confusion matrix saved to {save_path}")
-                except Exception as e:
-                    print(f"Error saving CNN_Transformer_Net confusion matrix: {e}")
-                plt.close()
-            else:
-                print("Warning: class_to_location mapping not available. Skipping confusion matrix.")
-
-        self.test_preds = []
-        self.test_targets = []
-        print('CNN_Transformer_Net on_test_epoch_end completed')
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc_reg(self._extract_features(x))

--- a/csi_dataset.py
+++ b/csi_dataset.py
@@ -4,202 +4,191 @@ from torch.utils.data import DataLoader, Dataset
 import numpy as np
 import glob
 import os
-
-from util import min_max_normalization, median_filter
 import re
+
 import torch
 from sklearn.model_selection import train_test_split
 import pandas as pd
 
+from util import min_max_normalization, median_filter
+
+
 class CSIDataset(Dataset):
-    def __init__(self, directory, time_step, stride=1, task='classification'):
+    """
+    Loads WiFi CSI data from CSV files and returns (sample, target) pairs
+    for indoor positioning regression.
+
+    Target format: float32 tensor [x, y] — the physical coordinates of the
+    measurement location (in grid units).
+
+    File naming: antenna_<antenna_id>_<x>_<y>.csv
+    Each location must have antenna_1, antenna_2, and antenna_3 files.
+    Each row in a CSV file represents one CSI measurement
+    (30 amplitude + 30 phase columns).
+    """
+
+    def __init__(self, directory: str, time_step: int, stride: int = 1):
         self.directory = directory
         self.time_step = time_step
-        self.stride = stride
-        self.task = task  # 'classification' or 'regression'
-        self.data_cache = {}  # Store all loaded data
-        
-        # Extract all unique location classes (x,y coordinates)
-        # Scan directory for all files to find unique locations
-        self.location_classes = set()
-        all_files = glob.glob(os.path.join(self.directory, 'antenna_*.csv'))
-        if not all_files:
-            raise FileNotFoundError(f"No CSV files found in directory {self.directory} with pattern 'antenna_*.csv'")
-            
-        for file_path in all_files:
-            match = re.search(r'antenna_\d+_(\d+)_(\d+).csv', os.path.basename(file_path))
-            if match:
-                x, y = map(int, match.groups())
-                self.location_classes.add((x, y))
-        
-        if not self.location_classes:
-            raise ValueError(f"No locations found from file names in {self.directory}")
+        self.stride    = stride
+        self.data_cache: dict = {}
 
-        # Create a mapping from (x,y) to class index
-        self.location_to_class = {loc: idx for idx, loc in enumerate(sorted(self.location_classes))}
+        # ---------- discover unique locations ----------
+        all_files = glob.glob(os.path.join(directory, 'antenna_*.csv'))
+        if not all_files:
+            raise FileNotFoundError(
+                f"No CSV files found in {directory} matching 'antenna_*.csv'")
+
+        location_classes: set = set()
+        for fp in all_files:
+            m = re.search(r'antenna_\d+_(\d+)_(\d+)\.csv', os.path.basename(fp))
+            if m:
+                location_classes.add((int(m.group(1)), int(m.group(2))))
+
+        if not location_classes:
+            raise ValueError(f"Could not parse any locations from file names in {directory}")
+
+        # Stable sorted mapping (kept for debugging / visualisation tools)
+        self.location_to_class = {loc: idx for idx, loc in enumerate(sorted(location_classes))}
         self.class_to_location = {idx: loc for loc, idx in self.location_to_class.items()}
-        self.num_classes = len(self.location_classes)
-        
-        print(f"Found {self.num_classes} unique location classes: {sorted(self.location_classes)}")
-        
-        # Load all CSV files into memory
+        self.num_classes = len(location_classes)
+        print(f"Found {self.num_classes} unique locations: {sorted(location_classes)}")
+
         self._load_all_data()
-        
-        self._prepare_index_map() # This will populate self.sample_info_list and self.total_samples
+        self._prepare_index_map()
+
+    # ------------------------------------------------------------------
 
     def _load_all_data(self):
-        """Load all CSV files into memory"""
         device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        
-        for location in self.location_to_class.keys():
+
+        for location in self.location_to_class:
             x, y = location
             file_paths = [
                 os.path.join(self.directory, f'antenna_1_{x}_{y}.csv'),
                 os.path.join(self.directory, f'antenna_2_{x}_{y}.csv'),
-                os.path.join(self.directory, f'antenna_3_{x}_{y}.csv')
+                os.path.join(self.directory, f'antenna_3_{x}_{y}.csv'),
             ]
-            
-            # Check if all files exist
-            if all(os.path.exists(fp) for fp in file_paths):
-                location_data = []
-                for file_path in file_paths:
-                    print(f"Loading {file_path}")
-                    df = pd.read_csv(file_path, na_values='#NAME?')
-                    amplitude_data = df.filter(regex='^amplitude_').values.astype(np.float32)
-                    phase_data = df.filter(regex='^phase_').values.astype(np.float32)
-                    
-                    if amplitude_data.shape[0] == 0 or phase_data.shape[0] == 0:
-                        raise ValueError(f"Empty data after filtering in file: {file_path}")
+            if not all(os.path.exists(fp) for fp in file_paths):
+                print(f"Warning: Missing antenna files for location {location}. Skipping.")
+                continue
 
-                    amplitude_data = min_max_normalization(median_filter(amplitude_data))
-                    phase_data = min_max_normalization(median_filter(phase_data))
-                    
-                    amplitude_tensor = torch.tensor(amplitude_data, dtype=torch.float32).to(device)
-                    phase_tensor = torch.tensor(phase_data, dtype=torch.float32).to(device)
-                    
-                    location_data.append((amplitude_tensor, phase_tensor))
-                
-                self.data_cache[location] = location_data
-            else:
-                print(f"Warning: Missing one or more antenna files for location {location}. Skipping this location.")
+            location_data = []
+            for fp in file_paths:
+                print(f"Loading {fp}")
+                df  = pd.read_csv(fp, na_values='#NAME?')
+                amp = df.filter(regex='^amplitude_').values.astype(np.float32)
+                pha = df.filter(regex='^phase_').values.astype(np.float32)
+
+                if amp.shape[0] == 0 or pha.shape[0] == 0:
+                    raise ValueError(f"Empty data in {fp}")
+
+                amp = min_max_normalization(median_filter(amp))
+                pha = min_max_normalization(median_filter(pha))
+
+                location_data.append((
+                    torch.tensor(amp, dtype=torch.float32).to(device),
+                    torch.tensor(pha, dtype=torch.float32).to(device),
+                ))
+            self.data_cache[location] = location_data
 
     def _prepare_index_map(self):
-        self.sample_info_list = []
-        for location in self.data_cache.keys():
-            # Get the number of rows from the first antenna's amplitude data
-            num_rows = self.data_cache[location][0][0].shape[0]  # amplitude_tensor shape[0]
-            
+        self.sample_info_list: list = []
+        for location, location_data in self.data_cache.items():
+            num_rows = location_data[0][0].shape[0]
             if num_rows < self.time_step:
-                print(f"Warning: Not enough data for location {location} for time_step {self.time_step}. Has {num_rows} rows. Skipping location {location}.")
+                print(f"Warning: location {location} has only {num_rows} rows "
+                      f"(< time_step={self.time_step}). Skipping.")
                 continue
-
             num_segments = (num_rows - self.time_step + 1) // self.stride
             if num_segments <= 0:
-                print(f"Warning: No segments generated for location {location} with {num_rows} rows, time_step {self.time_step}, stride {self.stride}. Skipping location {location}.")
                 continue
-                
-            for segment_idx in range(num_segments):
-                self.sample_info_list.append((location, segment_idx))
-        
+            for seg in range(num_segments):
+                self.sample_info_list.append((location, seg))
+
         self.total_samples = len(self.sample_info_list)
         if self.total_samples == 0:
-            raise ValueError("No valid samples found. Check data directory, file naming, and time_step/stride parameters.")
+            raise ValueError("No valid samples. Check data directory and time_step/stride.")
         print(f"Prepared {self.total_samples} total samples.")
+
+    # ------------------------------------------------------------------
 
     def __len__(self):
         return self.total_samples
 
     def __getitem__(self, idx):
-        location, segment_idx = self.sample_info_list[idx]
-        
-        # Get pre-loaded data
-        location_data = self.data_cache[location]
-        
-        start_idx = segment_idx * self.stride
-        end_idx = start_idx + self.time_step
+        location, seg_idx = self.sample_info_list[idx]
+        location_data     = self.data_cache[location]
 
-        # print(f"CSIDataset: Getting item {idx} for location {location}, segment_idx {segment_idx}, start_idx {start_idx}, end_idx {end_idx}")
+        start = seg_idx * self.stride
+        end   = start + self.time_step
 
-        all_channels_data = []
-        for antenna_idx in range(3):
-            amplitude_tensor, phase_tensor = location_data[antenna_idx]
-            all_channels_data.append(amplitude_tensor[start_idx:end_idx, :])
-            all_channels_data.append(phase_tensor[start_idx:end_idx, :])
-        
-        # Ensure all segments have the expected time_step length
-        for i, segment in enumerate(all_channels_data):
-            if segment.shape[0] != self.time_step:
-                raise ValueError(f"Segment {i} for sample {idx} (loc {location}, seg_idx {segment_idx}) has incorrect time_step {segment.shape[0]}, expected {self.time_step}. Start {start_idx}, End {end_idx}")
+        channels = []
+        for amp_t, pha_t in location_data:           # 3 antennas
+            channels.append(amp_t[start:end, :])
+            channels.append(pha_t[start:end, :])
 
-        sample_data = torch.stack(all_channels_data) # Shape: (6, time_step, num_subcarriers)
-        
+        sample_data = torch.stack(channels)           # (6, time_step, num_subcarriers)
+
         if idx == 0:
-            print(f"CSIDataset: sample_data shape: {sample_data.shape}, location: {location}, task: {self.task}")
-            print(f"CSIDataset: sample_data range - min: {sample_data.min():.4f}, max: {sample_data.max():.4f}")
+            print(f"CSIDataset sample[0]: shape={sample_data.shape}, location={location}, "
+                  f"min={sample_data.min():.4f}, max={sample_data.max():.4f}")
 
-        if self.task == 'regression':
-            x_coord, y_coord = location
-            target = torch.tensor([float(x_coord), float(y_coord)], dtype=torch.float32, device=sample_data.device)
-        else:
-            class_idx = self.location_to_class[location]
-            target = torch.tensor(class_idx, dtype=torch.long, device=sample_data.device)
-
+        x_coord, y_coord = location
+        target = torch.tensor([float(x_coord), float(y_coord)],
+                               dtype=torch.float32, device=sample_data.device)
         return sample_data, target
 
+
+# ---------------------------------------------------------------------------
+
 class CSIDataModule(pl.LightningDataModule):
-    def __init__(self, batch_size, num_workers, time_step, data_dir, stride, task='classification'):
+    """
+    PyTorch Lightning DataModule that loads CSI data and splits it into
+    train (60%) / val (20%) / test (20%) subsets.
+    """
+
+    def __init__(self, batch_size: int, num_workers: int,
+                 time_step: int, data_dir: str, stride: int):
         super().__init__()
-        self.batch_size = batch_size
+        self.batch_size  = batch_size
         self.num_workers = num_workers
-        self.time_step = time_step
-        self.data_dir = data_dir
-        self.stride = stride
-        self.task = task
+        self.time_step   = time_step
+        self.data_dir    = data_dir
+        self.stride      = stride
 
-        # 加载全部数据索引
-        self.dataset = CSIDataset(directory=self.data_dir, time_step=self.time_step, stride=self.stride, task=self.task)
-        self.num_classes = self.dataset.num_classes  # Store number of classes for model initialization
+        self.dataset     = CSIDataset(directory=data_dir, time_step=time_step, stride=stride)
+        self.num_classes = self.dataset.num_classes   # kept for visualisation tools
 
-        # --- Class Distribution Analysis ---
-        if hasattr(self.dataset, 'sample_info_list') and self.dataset.sample_info_list:
-            print("\n--- Class Distribution Analysis (Full Dataset) ---")
-            class_counts = {i: 0 for i in range(self.num_classes)}
-            
-            for sample_info in self.dataset.sample_info_list:
-                # sample_info is (location, segment_idx)
-                location = sample_info[0] 
-                class_idx = self.dataset.location_to_class[location]
-                class_counts[class_idx] += 1
-            
-            total_samples_from_distribution = 0
-            for i in range(self.num_classes):
-                location_coord = self.dataset.class_to_location[i]
-                count = class_counts[i]
-                print(f"Class {i} (Location: {location_coord}): {count} samples")
-                total_samples_from_distribution += count
-            
-            print(f"Total samples in distribution: {total_samples_from_distribution}")
-            # Verification:
-            if total_samples_from_distribution != self.dataset.total_samples:
-                print(f"Warning: Mismatch in total samples! Distribution sum: {total_samples_from_distribution}, CSIDataset.total_samples: {self.dataset.total_samples}")
-            print("--- End of Class Distribution Analysis ---\n")
-        else:
-            print("Warning: self.dataset.sample_info_list not available or empty. Skipping class distribution analysis.")
-        # --- End of Class Distribution Analysis ---
+        # Print sample counts per location
+        print("\n--- Location Sample Counts ---")
+        loc_counts: dict = {}
+        for location, _ in self.dataset.sample_info_list:
+            loc_counts[location] = loc_counts.get(location, 0) + 1
+        for loc in sorted(loc_counts):
+            print(f"  Location {loc}: {loc_counts[loc]} samples")
+        print(f"  Total: {self.dataset.total_samples}\n")
 
-        # 划分数据集
-        self.train_idx, test_idx = train_test_split(list(range(len(self.dataset))), test_size=0.4, random_state=42)
-        self.val_idx, self.test_idx = train_test_split(test_idx, test_size=0.5, random_state=42)
-        self.train_dataset = torch.utils.data.Subset(self.dataset, self.train_idx)
-        self.val_dataset = torch.utils.data.Subset(self.dataset, self.val_idx)
-        self.test_dataset = torch.utils.data.Subset(self.dataset, self.test_idx)
+        # Train / val / test split
+        indices = list(range(len(self.dataset)))
+        train_idx, tmp_idx = train_test_split(indices, test_size=0.4, random_state=42)
+        val_idx,   test_idx = train_test_split(tmp_idx,  test_size=0.5, random_state=42)
 
+        self.train_dataset = torch.utils.data.Subset(self.dataset, train_idx)
+        self.val_dataset   = torch.utils.data.Subset(self.dataset, val_idx)
+        self.test_dataset  = torch.utils.data.Subset(self.dataset, test_idx)
 
     def train_dataloader(self):
-        return DataLoader(self.train_dataset, batch_size=self.batch_size, num_workers=self.num_workers, shuffle=True, persistent_workers=self.num_workers > 0)
+        return DataLoader(self.train_dataset, batch_size=self.batch_size,
+                          num_workers=self.num_workers, shuffle=True,
+                          persistent_workers=self.num_workers > 0)
 
     def val_dataloader(self):
-        return DataLoader(self.val_dataset, batch_size=self.batch_size, num_workers=self.num_workers, persistent_workers=self.num_workers > 0)
+        return DataLoader(self.val_dataset, batch_size=self.batch_size,
+                          num_workers=self.num_workers,
+                          persistent_workers=self.num_workers > 0)
 
     def test_dataloader(self):
-        return DataLoader(self.test_dataset, batch_size=self.batch_size, num_workers=self.num_workers, persistent_workers=self.num_workers > 0)
+        return DataLoader(self.test_dataset, batch_size=self.batch_size,
+                          num_workers=self.num_workers,
+                          persistent_workers=self.num_workers > 0)

--- a/main.py
+++ b/main.py
@@ -1,49 +1,48 @@
 # 作者：程序员石磊，盗用卖钱可耻，在github即可搜到
 import os
 import argparse
+import torch
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping, LearningRateMonitor
 from pytorch_lightning.loggers import TensorBoardLogger
+
 from csi_dataset import CSIDataModule
 from cnn_net_model import CNN_Net
 from cnn_lstm_net_model import CNN_LSTM_Net
 from cnn_transformer_model import CNN_Transformer_Net
-import torch
 
 
 def get_callbacks(args):
-    monitor_metric = 'val_loss'
-    mode = 'min'
-
-    checkpoint_callback = ModelCheckpoint(
-        monitor=monitor_metric,
-        filename=f"{args.model_type}-best-{{epoch:02d}}-{{{monitor_metric}:.3f}}",
+    checkpoint_cb = ModelCheckpoint(
+        monitor='val_loss',
+        filename=f"{args.model_type}-best-{{epoch:02d}}-{{val_loss:.3f}}",
         save_top_k=1,
-        mode=mode,
-        save_last=True
+        mode='min',
+        save_last=True,
     )
-    early_stopping = EarlyStopping(
-        monitor=monitor_metric,
+    early_stop_cb = EarlyStopping(
+        monitor='val_loss',
         min_delta=0.001,
         patience=10,
         verbose=True,
-        mode=mode
+        mode='min',
     )
     lr_monitor = LearningRateMonitor(logging_interval='epoch')
-    return [checkpoint_callback, early_stopping, lr_monitor]
+    return [checkpoint_cb, early_stop_cb, lr_monitor]
 
 
-def get_model(args, num_classes):
+def get_model(args, num_classes: int):
+    """Instantiate the selected model architecture."""
     num_subcarriers = 30
     common = dict(
         lr=args.lr,
         lr_factor=args.lr_factor,
         lr_patience=args.lr_patience,
         lr_eps=args.lr_eps,
-        num_classes=num_classes,
+        num_classes=num_classes,        # kept for API compat; not used by regression
         time_step=args.time_step,
         num_subcarriers=num_subcarriers,
-        task=args.task,
+        reg_loss=args.reg_loss,
     )
     if args.model_type == 'cnn':
         return CNN_Net(**common)
@@ -51,8 +50,7 @@ def get_model(args, num_classes):
         return CNN_LSTM_Net(**common)
     elif args.model_type == 'cnn_transformer':
         return CNN_Transformer_Net(**common)
-    else:
-        raise ValueError(f"Invalid model type: {args.model_type}")
+    raise ValueError(f"Unknown model_type: {args.model_type}")
 
 
 def train(args):
@@ -62,15 +60,12 @@ def train(args):
         time_step=args.time_step,
         data_dir=args.data_dir,
         stride=args.stride,
-        task=args.task,
     )
-
-    model = get_model(args, data_module.num_classes)
-
-    logger = TensorBoardLogger("./logs", name=f"{args.model_type}")
+    model   = get_model(args, data_module.num_classes)
+    logger  = TensorBoardLogger('./logs', name=args.model_type)
 
     accelerator = 'gpu' if torch.cuda.is_available() else 'cpu'
-    print(accelerator)
+    print(f"Using accelerator: {accelerator}")
 
     trainer = pl.Trainer(
         accelerator=accelerator,
@@ -83,7 +78,7 @@ def train(args):
         min_steps=args.min_steps,
     )
     trainer.fit(model, datamodule=data_module)
-    trainer.test(model, data_module)
+    trainer.test(model, datamodule=data_module)
 
 
 def test(args):
@@ -93,12 +88,9 @@ def test(args):
         time_step=args.time_step,
         data_dir=args.data_dir,
         stride=args.stride,
-        task=args.task,
     )
+    logger = TensorBoardLogger('./logs', name=f'{args.model_type}_test')
 
-    logger = TensorBoardLogger(save_dir="./logs", name=f"{args.model_type}_test")
-
-    num_subcarriers = 30
     load_kwargs = dict(
         lr=args.lr,
         lr_factor=args.lr_factor,
@@ -106,8 +98,8 @@ def test(args):
         lr_eps=args.lr_eps,
         num_classes=data_module.num_classes,
         time_step=args.time_step,
-        num_subcarriers=num_subcarriers,
-        task=args.task,
+        num_subcarriers=30,
+        reg_loss=args.reg_loss,
     )
 
     if args.model_type == 'cnn':
@@ -117,7 +109,7 @@ def test(args):
     elif args.model_type == 'cnn_transformer':
         model = CNN_Transformer_Net.load_from_checkpoint(args.cpt_path, **load_kwargs)
     else:
-        raise ValueError(f"Invalid model type: {args.model_type}")
+        raise ValueError(f"Unknown model_type: {args.model_type}")
 
     accelerator = 'gpu' if torch.cuda.is_available() else 'cpu'
     trainer = pl.Trainer(
@@ -134,34 +126,48 @@ def test(args):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Train a neural network on WiFi CSI data")
-    parser.add_argument("--batch_size", type=int, default=64)
-    parser.add_argument("--num_workers", type=int, default=8)
-    parser.add_argument("--lr", type=float, default=0.001)
-    parser.add_argument("--lr_factor", type=float, default=0.1)
-    parser.add_argument("--lr_patience", type=int, default=10)
-    parser.add_argument("--lr_eps", type=float, default=1e-6)
-    parser.add_argument("--time_step", type=int, default=15)
-    parser.add_argument("--data_dir", type=str, default=os.getcwd() + "/dataset")
-    parser.add_argument('--min_epochs', default=10, type=int)
-    parser.add_argument('--max_epochs', default=120, type=int)
-    parser.add_argument('--min_steps', type=int, default=5)
-    parser.add_argument('--fast_dev_run', default=False, type=bool)
-    parser.add_argument('--stride', type=int, default=2)
-    parser.add_argument('--accelerator', default="gpu", type=str)
-    parser.add_argument('--devices', default=1, type=int)
-    parser.add_argument('--mode', choices=['test', 'train'], type=str, default='train')
-    parser.add_argument('--model_type', type=str, default='cnn',
+    parser = argparse.ArgumentParser(
+        description='WiFi CSI Indoor Positioning — Regression Training & Evaluation')
+
+    # ---- data ----
+    parser.add_argument('--data_dir',    type=str, default=os.path.join(os.getcwd(), 'dataset'))
+    parser.add_argument('--time_step',   type=int, default=15,
+                        help='Number of consecutive CSI rows per sample')
+    parser.add_argument('--stride',      type=int, default=2,
+                        help='Sliding window step between samples')
+    parser.add_argument('--num_workers', type=int, default=8)
+
+    # ---- model ----
+    parser.add_argument('--model_type',  type=str, default='cnn',
                         choices=['cnn', 'cnn_lstm', 'cnn_transformer'])
-    parser.add_argument('--task', type=str, default='classification',
-                        choices=['classification', 'regression'],
-                        help=(
-                            "Task type. 'classification' treats each (x,y) location as a separate class "
-                            "and reports accuracy. 'regression' predicts (x,y) coordinates directly and "
-                            "reports mean Euclidean distance error. Regression is recommended when "
-                            "classification accuracy is low due to many location classes."
-                        ))
-    parser.add_argument('--cpt_path', default=os.getcwd() + '/logs/cnn/version_0/checkpoints/last.ckpt', type=str)
+    parser.add_argument('--reg_loss',    type=str, default='smooth_l1',
+                        choices=['smooth_l1', 'mse', 'mae'],
+                        help=('Regression loss function. '
+                              'smooth_l1 (Huber): robust to outliers, recommended default. '
+                              'mse: penalises large errors more; sensitive to outliers. '
+                              'mae (L1): most robust; slower convergence.'))
+
+    # ---- training ----
+    parser.add_argument('--batch_size',  type=int,   default=64)
+    parser.add_argument('--lr',          type=float, default=0.001)
+    parser.add_argument('--lr_factor',   type=float, default=0.1,
+                        help='LR reduction factor for ReduceLROnPlateau')
+    parser.add_argument('--lr_patience', type=int,   default=10,
+                        help='Epochs without improvement before LR reduction')
+    parser.add_argument('--lr_eps',      type=float, default=1e-6)
+    parser.add_argument('--max_epochs',  type=int,   default=120)
+    parser.add_argument('--min_epochs',  type=int,   default=10)
+    parser.add_argument('--min_steps',   type=int,   default=5)
+    parser.add_argument('--fast_dev_run', default=False, type=bool,
+                        help='Run one batch for quick debugging')
+
+    # ---- mode ----
+    parser.add_argument('--mode',       type=str, default='train',
+                        choices=['train', 'test'])
+    parser.add_argument('--cpt_path',   type=str,
+                        default=os.path.join(os.getcwd(),
+                                             'logs/cnn/version_0/checkpoints/last.ckpt'),
+                        help='Checkpoint path (required for --mode test)')
 
     args = parser.parse_args()
     if args.mode == 'test':

--- a/readme.md
+++ b/readme.md
@@ -1,30 +1,31 @@
-**Project Name:** 
+**Project Name:**
 WIFI-SCI-Indoor-Positioning
 
 
 **Description:**
-WIFI-SCI-Indoor-Positioning is an innovative open-source project designed to leverage deep learning techniques for precise indoor positioning using WiFi Channel State Information (CSI). This project taps into the rich data provided by CSI, which includes information about the signal's amplitude, phase, and the propagation environment, to accurately estimate device locations inside buildings where GPS signals are unreliable.
+WIFI-SCI-Indoor-Positioning is an open-source project that leverages deep learning for precise indoor positioning using WiFi Channel State Information (CSI). The system directly regresses device coordinates (x, y) from CSI amplitude and phase data, enabling accurate location estimation in environments where GPS is unavailable.
 
 **Objective:**
-Our objective is to develop and refine models that can interpret complex patterns in CSI data, allowing for the accurate detection of a device's location based on the environmental characteristics reflected in the WiFi signals.
+Develop and refine deep learning models that interpret complex patterns in CSI data to predict device coordinates in continuous 2-D space, using mean Euclidean distance error as the primary evaluation metric.
 
 **How It Works:**
-- **Data Collection:** We collect CSI data from WiFi networks, capturing details that traditional RSSI-based systems overlook.
-- **Model Training:** We use various deep learning architectures, such as Convolutional Neural Networks (CNNs) and Recurrent Neural Networks (RNNs), to learn from the temporal and spatial characteristics of the CSI data.
-- **Position Estimation:** The trained models predict the location by interpreting the processed CSI data, considering factors like signal multipath effects, fading, and shadowing.
+- **Data Collection:** CSI data is collected from WiFi networks across predefined grid locations.
+- **Model Training:** CNN, CNN-LSTM, and CNN-Transformer architectures learn to map CSI fingerprints to (x, y) coordinates.
+- **Position Estimation:** Models output continuous coordinate predictions; performance is measured by mean and median distance error (in grid units).
 
 **Key Features:**
-- **High Accuracy:** By utilizing deep learning, the project aims to significantly improve the accuracy of indoor positioning compared to traditional methods.
-- **Scalability:** Designed to work seamlessly with existing WiFi infrastructure, making it easily scalable across different environments.
-- **Real-Time Processing:** Capable of processing live data to provide real-time location services.
-- **Community-Driven:** Encourages contributions from researchers and developers to further enhance the functionality and adaptability of the solution.
+- **Regression-based positioning:** Directly predict (x, y) coordinates — no discretisation, no class boundaries.
+- **Three model architectures:** CNN (fast baseline), CNN-LSTM (temporal modelling), CNN-Transformer (attention-based).
+- **Configurable regression loss:** `smooth_l1` (default), `mse`, or `mae`.
+- **Rich evaluation:** Mean / median distance error, within-N-unit hit rates, CDF plot, true-vs-predicted scatter plot.
+- **Scalable:** Works with existing WiFi infrastructure; no hardware changes required.
 
 **Potential Applications:**
-- Enhancing navigation systems in complex indoor environments such as airports, malls, and hospitals.
-- Enabling location-based services and advertisements.
-- Improving safety and security monitoring by providing precise location tracking within indoor spaces.
+- Navigation in airports, malls, and hospitals.
+- Location-based services.
+- Indoor asset tracking and safety monitoring.
 
-Below is the translated Chinese version of your project description:
+Below is the translated Chinese version:
 
 ---
 
@@ -34,34 +35,34 @@ WIFI-SCI-室内定位
 ---
 
 ## 项目描述：
-**WIFI-SCI-室内定位**是一个创新的开源项目，旨在利用深度学习技术，通过WiFi信道状态信息（CSI）实现精准的室内定位。本项目充分利用CSI提供的丰富数据，包括信号的幅度、相位以及传播环境信息，从而在GPS信号不可靠的室内环境中准确估算设备位置。
+**WIFI-SCI-室内定位**是一个开源项目，利用深度学习通过 WiFi 信道状态信息（CSI）实现精准室内定位。系统直接从 CSI 的幅度和相位数据中回归预测设备坐标 (x, y)，在 GPS 信号不可用的室内环境中实现准确的位置估算。
 
 ---
 
 ## 项目目标：
-我们的目标是开发和完善模型，使其能够解读CSI数据中的复杂模式，从而根据WiFi信号反映的环境特征准确检测设备的位置。
+开发和完善深度学习模型，将 CSI 指纹映射到连续二维坐标空间，以平均欧氏距离误差作为主要评估指标。
 
 ---
 
 ## 工作原理：
-* **数据收集：** 我们从WiFi网络收集CSI数据，捕捉传统基于RSSI（接收信号强度指示）的系统所忽略的细节。
-* **模型训练：** 我们使用各种深度学习架构，如卷积神经网络（CNN）和循环神经网络（RNN），从CSI数据的时间和空间特征中进行学习。
-* **位置估算：** 经过训练的模型通过解释处理后的CSI数据来预测位置，同时考虑信号多径效应、衰落和阴影等因素。
+* **数据收集：** 在预定义网格位置收集 WiFi CSI 数据（幅度 + 相位）。
+* **模型训练：** CNN、CNN-LSTM、CNN-Transformer 三种架构学习将 CSI 特征映射到 (x, y) 坐标。
+* **位置估算：** 模型输出连续坐标预测，以平均/中位欧氏距离误差（网格单元）衡量性能。
 
 ---
 
 ## 主要特点：
-* **高精度：** 通过利用深度学习，本项目旨在显著提高室内定位的精度，超越传统方法。
-* **可扩展性：** 旨在与现有WiFi基础设施无缝协作，使其在不同环境中易于扩展。
-* **实时处理：** 能够处理实时数据以提供实时定位服务。
-* **社区驱动：** 鼓励研究人员和开发者的贡献，以进一步增强解决方案的功能和适应性。
+* **回归定位：** 直接预测连续坐标，无需离散化，天然利用空间连续性先验。
+* **三种模型架构：** CNN（快速基线）、CNN-LSTM（时序建模）、CNN-Transformer（注意力机制）。
+* **可配置回归损失：** `smooth_l1`（默认）、`mse`、`mae`。
+* **丰富的评估指标：** 平均/中位距离误差、N 单元命中率、误差 CDF 图、真实 vs 预测散点图。
 
 ---
 
 ## 潜在应用：
 * 增强机场、商场和医院等复杂室内环境的导航系统。
 * 实现基于位置的服务和广告。
-* 通过在室内空间提供精准的位置跟踪，提高安全监控水平。
+* 通过室内空间精准位置跟踪提高安全监控水平。
 
 # 复现论文
 csi.pdf 仔细看在项目中
@@ -79,76 +80,92 @@ csi.pdf 仔细看在项目中
 
 
 # 数据集
-csv 文件 格式说明antenna_1_2_6.csv  antenna_天线号_坐标x_坐标y.csv
+csv 文件格式说明：`antenna_1_2_6.csv` → `antenna_天线号_坐标x_坐标y.csv`
 
 [全量csv数据集](https://pan.quark.cn/s/be9b44dd75b6)
 [全量dat原始数据集](https://pan.quark.cn/s/b2349706d0f6)
 
-注意：`dataset`目录中提供了少量数据集用于快速测试和演示，并非完整数据集。
+注意：`dataset` 目录中提供了少量数据集用于快速测试和演示，并非完整数据集。
 
 # 文件说明
 本项目基于 PyTorch Lightning 构建，主要文件包括：
 ```
-main.py                     # 训练、测试和预测的统一入口脚本
-csi_dataset.py              # PyTorch Dataset 和 DataLoader 实现，负责数据加载和预处理
-cnn_net_model.py            # 纯 CNN 模型架构
-cnn_lstm_net_model.py       # CNN + LSTM 混合模型架构
-cnn_transformer_model.py    # CNN + Transformer 混合模型架构
-util.py                     # 数据预处理工具函数 (如归一化、中值滤波)
-data_process.py             # (可选) 原始 .dat 文件到 .csv 文件的转换脚本
-heatmappic.py               # (可选) CSI 数据热力图生成，用于数据质量初步检查
-visualize_locations.py      # 可视化数据集中位置点的分布
-visualize_classification.py # 可视化模型分类结果 (混淆矩阵、准确率热图)
-analyze_spatial_confusion.py # 分析模型预测错误与物理空间距离的关系
-USAGE_GUIDE.md              # 详细的用户使用指南
-readme.md                   # 本项目概览文件 (您正在阅读的文件)
-csi.pdf                     # (参考) 项目可能复现或参考的相关论文
+main.py                     # 训练、测试统一入口脚本
+base_model.py               # 所有模型共用的回归训练/评估/可视化基类
+csi_dataset.py              # Dataset 和 DataModule，输出 float32 [x,y] 坐标目标
+cnn_net_model.py            # 纯 CNN 回归模型
+cnn_lstm_net_model.py       # CNN + LSTM 回归模型
+cnn_transformer_model.py    # CNN + Transformer 回归模型
+util.py                     # 数据预处理工具 (归一化、中值滤波)
+data_process.py             # (可选) 原始 .dat → .csv 转换脚本
+heatmappic.py               # (可选) CSI 数据热力图，用于数据质量检查
+visualize_locations.py      # 可视化数据集中位置点的空间分布
+USAGE_GUIDE.md              # 详细使用指南
+readme.md                   # 本文件
+csi.pdf                     # 参考论文
 ```
 
 # Python 实现说明
 
 ## 数据集处理 (`csi_dataset.py`)
-- 采用 PyTorch 的 `Dataset` 和 `DataLoader` 机制高效处理CSI数据。
-- 输入数据为 **6通道**，由3个天线的幅度和相位数据构成 (`3 antennas * (1 amplitude + 1 phase) = 6 channels`)。
-- 使用 `OrderedDict` 实现数据缓存机制，加速重复数据块的加载，提高训练效率。
-- 将室内定位问题从坐标回归转换为**分类问题**，每个唯一的 `(x,y)` 坐标被视为一个独立的类别。
-- 自动扫描数据集目录，提取所有唯一位置点，并创建位置到类别索引 (`location_to_class`) 和类别索引到位置 (`class_to_location`) 的映射。
+- 采用 PyTorch 的 `Dataset` 和 `DataLoader` 机制高效处理 CSI 数据。
+- 输入数据为 **6 通道**：3 个天线 × (幅度 + 相位)，形状 `(6, time_step, num_subcarriers)`。
+- 每个样本的目标为 **float32 张量 `[x, y]`**，即对应位置的物理坐标（网格单元）。
+- 使用滑动窗口（`time_step`、`stride`）从连续 CSI 测量序列中生成训练样本。
+- 数据集自动扫描目录，发现所有唯一位置点。
 
 ## 网络模型
-本项目提供了三种基于 PyTorch Lightning 实现的深度学习模型：
+本项目提供三种基于 PyTorch Lightning 的深度学习回归模型，均继承自 `CSIBaseModel`：
 
 ### 1. CNN 模型 (`cnn_net_model.py`)
--   **架构**: 纯卷积神经网络。包含三层2D卷积层 (`nn.Conv2d`)，主要用于提取CSI数据中的空间特征。
--   **特点**: 结构相对简单，训练速度快，适合作为基线模型或在计算资源受限时使用。
+- **架构**：3 层 Conv2d（保持空间尺寸）→ Flatten → FC(1024) → FC(512) → FC(2)
+- **特点**：结构简单，训练速度快，适合快速基线实验。
 
-### 2. CNN + LSTM 模型 (`cnn_lstm_net_model.py`)
--   **架构**: 结合了CNN和长短期记忆网络 (LSTM)。首先通过CNN提取空间特征，然后将这些特征序列输入到LSTM层 (`nn.LSTM`) 以捕捉数据的时间依赖性。
--   **特点**: 能够同时学习CSI数据的空间和时间特性，通常在处理具有时序性的CSI数据时表现更优，是本项目推荐尝试的主力模型之一。
+### 2. CNN + LSTM 模型 (`cnn_lstm_net_model.py`)（**推荐**）
+- **架构**：3 层 Conv2d → Reshape → LSTM(hidden=100) → 取最后时间步 → FC(2)
+- **特点**：同时捕获空间特征（CNN）和时序依赖（LSTM），通常取得最佳精度。
 
 ### 3. CNN + Transformer 模型 (`cnn_transformer_model.py`)
--   **架构**: 结合了CNN和Transformer编码器。通过CNN进行初步特征提取和降维，然后将输出序列输入Transformer编码器 (`nn.TransformerEncoder`)，利用其自注意力机制学习序列内的复杂关系。
--   **特点**: Transformer具有强大的序列建模能力，可能在捕捉CSI数据中更长距离或更复杂的依赖关系方面有优势。对超参数和数据量可能更敏感。
+- **架构**：2 层 Conv2d + MaxPool → Reshape 为序列 → TransformerEncoder → 取首 token → FC(2)
+- **特点**：自注意力机制捕获长程依赖，复杂场景下可能有优势；对超参数较敏感。
 
 所有模型均：
-- 同时支持**分类任务**（`--task classification`）和**回归任务**（`--task regression`）。
-- 分类任务使用 `CrossEntropyLoss`，监控准确率，并生成混淆矩阵。
-- 回归任务使用 `SmoothL1Loss`，监控平均欧氏距离误差，并生成 CDF 和散点图。
-- 支持生成详细的可视化分析图表。
+- 输出层为 `nn.Linear(feature_dim, 2)`，直接预测连续坐标 `(x, y)`
+- 支持三种回归损失（`--reg_loss`）：`smooth_l1`（默认）、`mse`、`mae`
+- 训练监控指标：`train_loss`、`train_dist`、`val_loss`、`val_dist`
+- 测试结果：平均/中位距离误差、N 单元命中率、误差 CDF 图、散点图
 
 ## 训练与评估 (`main.py`)
-- 基于 PyTorch Lightning 实现，简化了训练循环、GPU使用、日志记录等。
-- 支持通过命令行参数配置模型类型、学习率、批大小、训练周期等。
-- 集成了早停 (EarlyStopping) 和学习率调度 (ReduceLROnPlateau) 等高级训练策略。
-- 自动保存最佳模型检查点和最后一个检查点。
+- 基于 PyTorch Lightning，自动处理 GPU 加速、日志、检查点。
+- 集成早停（`EarlyStopping`）和学习率自动衰减（`ReduceLROnPlateau`）。
+- 训练结束后自动在测试集上评估并保存可视化结果。
 
-## 数据可视化
-- `visualize_locations.py`: 可视化数据集中所有位置点的空间分布。
-- `visualize_classification.py`: 加载已训练模型，评估其在测试集上的表现，并生成混淆矩阵和分类准确率热图。
-- `analyze_spatial_confusion.py`: 分析模型预测错误的位置与真实位置之间的物理距离，帮助理解模型的混淆模式。
+## 回归实现关键点
+
+1. **输出层**：预测连续 (x, y) 坐标
+   ```python
+   self.fc_reg = nn.Linear(feature_dim, 2)
+   ```
+
+2. **损失函数**（可选，通过 `--reg_loss` 指定）
+   ```python
+   loss = F.smooth_l1_loss(pred, target)  # target: float32 [x, y]
+   ```
+
+3. **距离误差**（训练时实时监控）
+   ```python
+   dist = torch.sqrt(((pred - target) ** 2).sum(dim=1)).mean()
+   ```
+
+4. **测试指标**
+   - 平均欧氏距离误差（Mean Distance Error）
+   - 中位距离误差（Median Distance Error）
+   - Within-N 命中率：预测点与真实点距离 ≤ N 网格单元的样本比例
+   - 误差 CDF 图 + 真实 vs 预测散点图（保存至 `results/<model>_results/`）
 
 ## 详细使用说明
 
-有关环境配置、数据准备、模型训练、参数调整和结果分析的完整详细步骤，请参阅 **[详细使用指南 (USAGE_GUIDE.md)](./USAGE_GUIDE.md)**。
+有关环境配置、数据准备、模型训练、参数调整和结果分析的完整步骤，请参阅 **[详细使用指南 (USAGE_GUIDE.md)](./USAGE_GUIDE.md)**。
 
 # Email
 zhangleilikejay@gmail.com
@@ -157,89 +174,32 @@ zhangleilikejay@gmail.com
 
 ## 环境要求
 - Python 3.8+
-- PyTorch (推荐1.12+ 或更高版本，支持CUDA)
-- PyTorch Lightning (推荐1.6+ 或更高版本)
-- 详细依赖请参见 `USAGE_GUIDE.md` 中的环境配置部分。
+- PyTorch ≥ 1.12（推荐支持 CUDA 版本）
+- PyTorch Lightning ≥ 1.6
+- 详细依赖请参见 `USAGE_GUIDE.md`。
 
 ## 数据格式
-- 输入数据为CSV文件，命名格式: `antenna_<天线号>_<x坐标>_<y坐标>.csv`。
-- 每个CSV文件包含多行CSI样本，每行代表一个时间点的测量。
-- 列包含幅度和相位数据，例如: `amplitude_0`, ..., `amplitude_N-1`, `phase_0`, ..., `phase_N-1`。
-- 详细说明请参见 `USAGE_GUIDE.md`。
+- CSV 文件命名：`antenna_<天线号>_<x坐标>_<y坐标>.csv`
+- 每行为一个时间点的 CSI 测量，列格式：`amplitude_0 … amplitude_29, phase_0 … phase_29`
+- 每个位置需有 `antenna_1`, `antenna_2`, `antenna_3` 三个文件
+
 ## 指纹地图
 
 ![map](https://github.com/zhangleino1/WIFI-SCI-Indoor-Positioning/blob/main/images/wechat_2025-08-21_093130_935.png?raw=true)
 
-## 分类精度低的原因分析
-
-**为什么分类精度会很低？** 以下是常见原因：
-
-1. **类别数量过多**：10×10 网格有 100 个类别，随机猜测基准仅为 1%，区分 100 个类别难度极高。
-2. **损失函数忽略空间关系**：`CrossEntropyLoss` 对所有错误预测一视同仁——将 `(0,0)` 预测为相邻的 `(1,0)` 与预测为 `(9,9)` 受到相同的惩罚，模型无法从"距离"获得梯度信号。
-3. **每类样本量有限**：每个位置约 400 个样本（滑窗后），100 类分类任务数据量不足。
-4. **位置定位本质上是回归问题**：坐标在空间中是连续的，分类方法将连续空间离散化，丢失了空间结构信息。
-
-**推荐方案：切换到回归模式（`--task regression`）**
-
-回归模式直接预测 `(x, y)` 坐标，使用平均欧氏距离误差（MED）评估，通常比分类精度更高且更直观。
-
-## 任务模式说明（分类 vs 回归）
-
-| 模式 | 参数 | 输出层 | 损失函数 | 评估指标 |
-|------|------|--------|---------|---------|
-| 分类 | `--task classification` | `num_classes` 个神经元 | CrossEntropyLoss | 准确率 + 混淆矩阵 |
-| 回归 | `--task regression` | 2 个神经元 (x, y) | SmoothL1Loss | 平均欧氏距离误差 + CDF |
-
-## 分类实现关键点
-1. **类别映射**: 将每个唯一的 (x,y) 坐标作为一个分类类别
-   ```python
-   self.location_to_class = {loc: idx for idx, loc in enumerate(sorted(self.location_classes))}
-   ```
-
-2. **分类输出层**:
-   ```python
-   self.fc3 = nn.Linear(512, num_classes)  # 输出类别数量的神经元
-   ```
-
-3. **分类损失函数**:
-   ```python
-   loss = F.cross_entropy(logits, targets)
-   ```
-
-## 回归实现关键点
-1. **回归输出层**: 输出 2 个神经元，直接预测 `(x, y)` 坐标
-   ```python
-   self.fc3 = nn.Linear(512, 2)  # 输出 (x, y) 坐标
-   ```
-
-2. **回归损失函数**: 使用 SmoothL1Loss（对异常值更鲁棒）
-   ```python
-   loss = F.smooth_l1_loss(output, targets)  # targets 为 [x, y] float tensor
-   ```
-
-3. **距离误差评估**:
-   ```python
-   dist = torch.sqrt(((output - targets) ** 2).sum(dim=1)).mean()
-   ```
-
-## 可视化分析方法
-- **混淆矩阵分析**: 识别模型在哪些位置类别之间容易产生混淆。
-- **位置准确率热图**: 直观展示模型在不同物理位置上的预测准确率。
-- **物理距离误差分析**: 分析错误分类的样本与其真实位置和预测位置之间的物理（欧几里得）距离。
-
-# 报错 注意安装
+# 报错注意安装
 ```powershell
-# 强烈建议参照 USAGE_GUIDE.md 中的详细环境配置步骤进行安装
-# 关键依赖:
-# conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch -c nvidia (根据您的CUDA版本调整)
-# conda install lightning -c conda-forge
-# pip install scikit-learn matplotlib seaborn pandas tensorboard
+# 参照 USAGE_GUIDE.md 中的详细环境配置步骤
+conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch -c nvidia
+conda install lightning -c conda-forge
+pip install scikit-learn matplotlib seaborn pandas tensorboard
 ```
 
 # 可能的未来优化方向
-- 添加多传感器融合功能，结合其他定位数据源
-- 开发在线学习模块，使系统能够适应环境变化
-- 增加少样本学习能力，减少每个位置需要的训练数据量
+- 多传感器融合，结合其他定位数据源
+- 在线学习模块，使系统适应环境变化
+- 少样本学习，减少每个位置所需的训练数据量
+- 联合分类 + 回归多任务学习
 
 # csi data image filter
 


### PR DESCRIPTION
- Remove --task parameter; system is now regression-only
- Add --reg_loss (smooth_l1/mse/mae, default smooth_l1)
- Add base_model.py: shared CSIBaseModel base class with all training/evaluation/visualization logic (CDF plot, scatter plot, mean/median/hit-rate metrics)
- Rewrite csi_dataset.py: always returns float32 [x,y] targets
- Rewrite cnn_net_model.py, cnn_lstm_net_model.py, cnn_transformer_model.py to inherit CSIBaseModel
- Rewrite main.py: remove --task, add --reg_loss
- Rewrite readme.md and USAGE_GUIDE.md: remove all classification content, document regression-only workflow

https://claude.ai/code/session_01SmyrPKqwrvunepKU9JX1P8